### PR TITLE
rename mammos-units

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
   { name = "Hans Fangohr" },
 ]
 
-dependencies = ["mammosunits", "EMMOntoPy", "numpy"]
+dependencies = ["mammos-units", "EMMOntoPy", "numpy"]
 
 
 [tool.ruff.lint]

--- a/src/mammos_entity/base.py
+++ b/src/mammos_entity/base.py
@@ -1,6 +1,6 @@
 import abc
 
-import mammosunits as u
+import mammos_units as u
 from owlready2.entity import ThingClass
 
 from mammos_entity.onto import mammos_ontology

--- a/src/mammos_entity/entities.py
+++ b/src/mammos_entity/entities.py
@@ -1,4 +1,4 @@
-import mammosunits as u
+import mammos_units as u
 
 from mammos_entity.base import AbstractEntity
 


### PR DESCRIPTION
The name of the `mammos-units` package has been updated in order to match our conventions.

@swapneelap please merge when you are happy.