### PR TITLE
add ontology_label_with_iri to quickstart notebook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+- Entity objects have `ontology_label_with_iri` attribute

--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "id": "e51d915f-2c57-4336-93c1-5099db9e29cd",
    "metadata": {},
    "outputs": [],
@@ -48,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "id": "64fa0a25-5b84-4a74-bc0c-a3c3583892e8",
    "metadata": {
     "editable": true,
@@ -70,9 +70,6 @@
    "outputs": [
     {
      "data": {
-      "text/latex": [
-       "SpontaneousMagnetization(value=800000.0, unit=A / m)"
-      ],
       "text/plain": [
        "SpontaneousMagnetization(value=800000.0, unit=A / m)"
       ]
@@ -104,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 4,
    "id": "361a9784-08b1-4684-afd0-9a4ef8217a7d",
    "metadata": {
     "editable": true,
@@ -120,7 +117,7 @@
        "SpontaneousMagnetization(value=800000.0, unit=A / m)"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -146,7 +143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 5,
    "id": "44b99b71-d47f-4999-8869-a3d3f7d6d6ed",
    "metadata": {
     "editable": true,
@@ -162,7 +159,7 @@
        "SpontaneousMagnetization(value=800.0, unit=kA / m)"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -174,7 +171,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "id": "89857bdb-200e-48e0-a6c7-4cab8a93bbec",
    "metadata": {
     "editable": true,
@@ -190,7 +187,7 @@
        "np.True_"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -215,7 +212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 7,
    "id": "682a8b31-c11b-4b7a-a354-45ce6ce24e19",
    "metadata": {
     "editable": true,
@@ -234,7 +231,7 @@
        "<Quantity 800000. A / m>"
       ]
      },
-     "execution_count": 72,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -248,7 +245,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 8,
    "id": "29ed6fcc-7b0d-4d3d-8176-2f29ee1038e9",
    "metadata": {
     "editable": true,
@@ -264,7 +261,7 @@
        "SpontaneousMagnetization(value=800000.0, unit=A / m)"
       ]
      },
-     "execution_count": 73,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -289,7 +286,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 9,
    "id": "ba59bfdc-a785-4e21-ada1-cde2195d601e",
    "metadata": {
     "editable": true,
@@ -306,12 +303,12 @@
      "evalue": "The unit T does not match the units of SpontaneousMagnetization",
      "output_type": "error",
      "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[74], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mme\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mMs\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m1.2\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mT\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m  \u001b[38;5;66;03m# Tesla not compatible with A/m\u001b[39;00m\n",
-      "File \u001b[0;32m/srv/conda/envs/notebook/lib/python3.12/site-packages/mammos_entity/entities.py:35\u001b[0m, in \u001b[0;36mMs\u001b[0;34m(value, unit)\u001b[0m\n\u001b[1;32m     20\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21mMs\u001b[39m(\n\u001b[1;32m     21\u001b[0m     value: \u001b[38;5;28mint\u001b[39m \u001b[38;5;241m|\u001b[39m \u001b[38;5;28mfloat\u001b[39m \u001b[38;5;241m|\u001b[39m typing\u001b[38;5;241m.\u001b[39mArrayLike \u001b[38;5;241m=\u001b[39m \u001b[38;5;241m0\u001b[39m, unit: \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;241m|\u001b[39m \u001b[38;5;28mstr\u001b[39m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[1;32m     22\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m mammos_entity\u001b[38;5;241m.\u001b[39mEntity:\n\u001b[1;32m     23\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Create an Entity representing the spontaneous magnetization (Ms).\u001b[39;00m\n\u001b[1;32m     24\u001b[0m \n\u001b[1;32m     25\u001b[0m \u001b[38;5;124;03m    Args:\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     33\u001b[0m \n\u001b[1;32m     34\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m---> 35\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mEntity\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mSpontaneousMagnetization\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mvalue\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43munit\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m/srv/conda/envs/notebook/lib/python3.12/site-packages/mammos_entity/base.py:124\u001b[0m, in \u001b[0;36mEntity.__new__\u001b[0;34m(cls, ontology_label, value, unit, **kwargs)\u001b[0m\n\u001b[1;32m    122\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m (si_unit \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m) \u001b[38;5;129;01mand\u001b[39;00m (unit \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m):\n\u001b[1;32m    123\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m u\u001b[38;5;241m.\u001b[39mUnit(si_unit)\u001b[38;5;241m.\u001b[39mis_equivalent(unit):\n\u001b[0;32m--> 124\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m(\n\u001b[1;32m    125\u001b[0m             \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mThe unit \u001b[39m\u001b[38;5;132;01m{\u001b[39;00munit\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m does not match the units of \u001b[39m\u001b[38;5;132;01m{\u001b[39;00montology_label\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    126\u001b[0m         )\n\u001b[1;32m    127\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m (si_unit \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m) \u001b[38;5;129;01mand\u001b[39;00m (unit \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m):\n\u001b[1;32m    128\u001b[0m     \u001b[38;5;28;01mwith\u001b[39;00m u\u001b[38;5;241m.\u001b[39madd_enabled_aliases({\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mCel\u001b[39m\u001b[38;5;124m\"\u001b[39m: u\u001b[38;5;241m.\u001b[39mK, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mmCel\u001b[39m\u001b[38;5;124m\"\u001b[39m: u\u001b[38;5;241m.\u001b[39mK}):\n",
-      "\u001b[0;31mTypeError\u001b[0m: The unit T does not match the units of SpontaneousMagnetization"
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mTypeError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[9]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[43mme\u001b[49m\u001b[43m.\u001b[49m\u001b[43mMs\u001b[49m\u001b[43m(\u001b[49m\u001b[32;43m1.2\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mT\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m)\u001b[49m  \u001b[38;5;66;03m# Tesla not compatible with A/m\u001b[39;00m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/git/mammos-devtools/packages/mammos-entity/src/mammos_entity/_entities.py:35\u001b[39m, in \u001b[36mMs\u001b[39m\u001b[34m(value, unit)\u001b[39m\n\u001b[32m     20\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mMs\u001b[39m(\n\u001b[32m     21\u001b[39m     value: \u001b[38;5;28mint\u001b[39m | \u001b[38;5;28mfloat\u001b[39m | typing.ArrayLike = \u001b[32m0\u001b[39m, unit: \u001b[38;5;28;01mNone\u001b[39;00m | \u001b[38;5;28mstr\u001b[39m = \u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[32m     22\u001b[39m ) -> mammos_entity.Entity:\n\u001b[32m     23\u001b[39m \u001b[38;5;250m    \u001b[39m\u001b[33;03m\"\"\"Create an Entity representing the spontaneous magnetization (Ms).\u001b[39;00m\n\u001b[32m     24\u001b[39m \n\u001b[32m     25\u001b[39m \u001b[33;03m    Args:\u001b[39;00m\n\u001b[32m   (...)\u001b[39m\u001b[32m     33\u001b[39m \n\u001b[32m     34\u001b[39m \u001b[33;03m    \"\"\"\u001b[39;00m\n\u001b[32m---> \u001b[39m\u001b[32m35\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mEntity\u001b[49m\u001b[43m(\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mSpontaneousMagnetization\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mvalue\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43munit\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/git/mammos-devtools/packages/mammos-entity/src/mammos_entity/_base.py:124\u001b[39m, in \u001b[36mEntity.__new__\u001b[39m\u001b[34m(cls, ontology_label, value, unit, **kwargs)\u001b[39m\n\u001b[32m    122\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m (si_unit \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m) \u001b[38;5;129;01mand\u001b[39;00m (unit \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m):\n\u001b[32m    123\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m u.Unit(si_unit).is_equivalent(unit):\n\u001b[32m--> \u001b[39m\u001b[32m124\u001b[39m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mTypeError\u001b[39;00m(\n\u001b[32m    125\u001b[39m             \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mThe unit \u001b[39m\u001b[38;5;132;01m{\u001b[39;00munit\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m does not match the units of \u001b[39m\u001b[38;5;132;01m{\u001b[39;00montology_label\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m\n\u001b[32m    126\u001b[39m         )\n\u001b[32m    127\u001b[39m \u001b[38;5;28;01melif\u001b[39;00m (si_unit \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m) \u001b[38;5;129;01mand\u001b[39;00m (unit \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m):\n\u001b[32m    128\u001b[39m     \u001b[38;5;28;01mwith\u001b[39;00m u.add_enabled_aliases({\u001b[33m\"\u001b[39m\u001b[33mCel\u001b[39m\u001b[33m\"\u001b[39m: u.K, \u001b[33m\"\u001b[39m\u001b[33mmCel\u001b[39m\u001b[33m\"\u001b[39m: u.K}):\n",
+      "\u001b[31mTypeError\u001b[39m: The unit T does not match the units of SpontaneousMagnetization"
      ]
     }
    ],
@@ -321,7 +318,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 10,
    "id": "18a41a69-2b83-4b96-aeeb-0dfa4f65adc6",
    "metadata": {
     "editable": true,
@@ -337,7 +334,7 @@
        "SpontaneousMagnetization(value=954929.6580315315, unit=A / m)"
       ]
      },
-     "execution_count": 78,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -369,7 +366,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 11,
    "id": "579387e3-2edc-498e-973f-7501e96c9e21",
    "metadata": {
     "editable": true,
@@ -385,7 +382,7 @@
        "'SpontaneousMagnetization'"
       ]
      },
-     "execution_count": 88,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -409,8 +406,45 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "4206aba4-5070-4c24-b15e-4e1eb4cc251b",
+   "metadata": {},
+   "source": [
+    "When saving data to a file, this `ontology_label_with_iri` might be useful to save in the metadata as it returns a string containing the ontology label together with the unique identifier of the ontology entry (IRI is the Internationalized Resource Identifier)."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 12,
+   "id": "b562c07c-f4cd-49fb-8994-522af7bdb81f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'SpontaneousMagnetization https://w3id.org/emmo/domain/magnetic_material#EMMO_032731f8-874d-5efb-9c9d-6dafaa17ef25'"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Ms.ontology_label_with_iri"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6cb4fcd0-becb-472a-99ef-a8bf8bc5985a",
+   "metadata": {},
+   "source": [
+    "We can use all attributes of the ontology object through `Ms.ontology`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
    "id": "827c6af2-3435-4905-a791-755b9fa6e9c1",
    "metadata": {
     "editable": true,
@@ -430,7 +464,7 @@
        " 'IECEntry': ['https://www.electropedia.org/iev/iev.nsf/display?openform&ievref=221-02-41']}"
       ]
      },
-     "execution_count": 89,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -441,7 +475,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": 14,
    "id": "e0beecfe-ffd3-4477-8594-c82552281a92",
    "metadata": {
     "editable": true,
@@ -455,14 +489,14 @@
      "data": {
       "text/plain": [
        "{emmo.hasMeasurementUnit,\n",
-       " core.altLabel,\n",
-       " core.prefLabel,\n",
-       " emmo.elucidation,\n",
        " magnetic_material_mammos.IECEntry,\n",
-       " magnetic_material_mammos.wikipediaReference}"
+       " core.prefLabel,\n",
+       " magnetic_material_mammos.wikipediaReference,\n",
+       " core.altLabel,\n",
+       " emmo.elucidation}"
       ]
      },
-     "execution_count": 101,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -473,7 +507,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": 15,
    "id": "791b4d91-b2ea-41a8-8a9b-69bd251b302c",
    "metadata": {
     "editable": true,
@@ -527,7 +561,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 16,
    "id": "36fb7fda-524a-417d-bff4-00fd82249956",
    "metadata": {
     "editable": true,
@@ -543,7 +577,7 @@
        "np.float64(800000.0)"
       ]
      },
-     "execution_count": 84,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -554,7 +588,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 17,
    "id": "401b885a-5bd8-48c2-8a5b-abfff441ecdf",
    "metadata": {
     "editable": true,
@@ -573,7 +607,7 @@
        "Unit(\"A / m\")"
       ]
      },
-     "execution_count": 85,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -584,7 +618,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 18,
    "id": "632171ed-70e4-42f4-9f72-4c1dfc424fb4",
    "metadata": {
     "editable": true,
@@ -597,10 +631,10 @@
     {
      "data": {
       "text/plain": [
-       "SpontaneousMagnetization(value=800.0, unit=kA / m)"
+       "SpontaneousMagnetization(value=800000.0, unit=A / m)"
       ]
      },
-     "execution_count": 86,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -625,7 +659,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": 19,
    "id": "c30dc86d-3aa4-40ab-870b-67edacf5e668",
    "metadata": {
     "editable": true,
@@ -644,7 +678,7 @@
        "<Quantity 6.4e+11 A2 / m2>"
       ]
      },
-     "execution_count": 91,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -669,7 +703,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 20,
    "id": "9e5fed48-d7a8-4fe9-b5ce-c8dfe2d16d57",
    "metadata": {
     "editable": true,
@@ -688,7 +722,7 @@
        "<Quantity 800000. A / m>"
       ]
      },
-     "execution_count": 95,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -713,7 +747,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": 21,
    "id": "e2154132-777d-44ec-9797-683fdcf79d64",
    "metadata": {
     "editable": true,
@@ -729,7 +763,7 @@
        "ExternalMagneticField(value=[10000. 10000. 10000.], unit=A / m)"
       ]
      },
-     "execution_count": 97,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -741,7 +775,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": 22,
    "id": "561dd831-4367-4d80-8416-6f61c7a82d21",
    "metadata": {
     "editable": true,
@@ -757,7 +791,7 @@
        "magnetic_material_mammos.ExternalMagneticField"
       ]
      },
-     "execution_count": 98,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -768,7 +802,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": 23,
    "id": "bd6389fc-2f74-4ade-ad2d-bf4448c03974",
    "metadata": {
     "editable": true,
@@ -824,7 +858,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 130,
+   "execution_count": 24,
    "id": "e30ea9fe-23bb-424e-ae8d-2cd6b789be71",
    "metadata": {
     "editable": true,
@@ -853,7 +887,7 @@
        " magnetic_material_mammos.SwitchingFieldCoercivityExternal}"
       ]
      },
-     "execution_count": 130,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -878,7 +912,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 135,
+   "execution_count": 25,
    "id": "2b8226c8-a13e-436e-90db-3e5f1665a48d",
    "metadata": {
     "editable": true,
@@ -894,7 +928,7 @@
        "ElectricFieldStrength(value=230.0, unit=kg m / (A s3))"
       ]
      },
-     "execution_count": 135,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -920,7 +954,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,

--- a/src/mammos_entity/_base.py
+++ b/src/mammos_entity/_base.py
@@ -161,6 +161,24 @@ class Entity(u.Quantity):
         """
         return self._ontology_label
 
+    @property
+    def ontology_label_with_iri(self) -> str:
+        """The ontology label with its Iri. Unique link to EMMO ontology.
+
+        Returns the `self.ontology_label` together with the IRI (a URL that
+        points to the definition of this entity.)
+
+        If only the IRI is desired, one can use `self.ontology.iri`.
+
+        Returns:
+            str: The ontology label corresponding to the right ThingClass,
+                 together with the IRI.
+
+        """
+        label_with_iri = self.ontology_label + " " + self.ontology.iri
+
+        return label_with_iri
+
     # FIX: right not this will fail if no internet!
     @property
     def ontology(self) -> owlready2.entity.ThingClass:

--- a/src/mammos_entity/_base.py
+++ b/src/mammos_entity/_base.py
@@ -163,10 +163,11 @@ class Entity(u.Quantity):
 
     @property
     def ontology_label_with_iri(self) -> str:
-        """The ontology label with its Iri. Unique link to EMMO ontology.
+        """The ontology label with its IRI. Unique link to EMMO ontology.
 
         Returns the `self.ontology_label` together with the IRI (a URL that
-        points to the definition of this entity.)
+        points to the definition of this entity.) IRI stands for
+        Internationalized Resource Identifier.
 
         If only the IRI is desired, one can use `self.ontology.iri`.
 

--- a/tests/test_predefined_entities.py
+++ b/tests/test_predefined_entities.py
@@ -204,3 +204,16 @@ def test_unique_labels():
         )
         == 8
     )
+
+
+def test_ontology_label():
+    Ms = me.Ms(8e5, "A/m")
+    assert Ms.ontology_label == "SpontaneousMagnetization"
+
+
+def test_ontology_label_with_iri():
+    Ms = me.Ms(8e5, "A/m")
+    assert (
+        Ms.ontology_label_with_iri
+        == "SpontaneousMagnetization https://w3id.org/emmo/domain/magnetic_material#EMMO_032731f8-874d-5efb-9c9d-6dafaa17ef25"
+    )


### PR DESCRIPTION
New property:

```python
Ms = me.Ms(8e5, "A/m")
Ms.ontology_label_with_iri
```
returns
```
'SpontaneousMagnetization https://w3id.org/emmo/domain/magnetic_material#EMMO_032731f8-874d-5efb-9c9d-6dafaa17ef25'
```

Motivation for choice of name:

- start with `ontology` because all numpy attributes are in the names space, and we have used `ontology` already in `ontology` and `ontology_label`. So it is easier to find.
- could have used something like `ontology_full_specification` instead, but I think we don't quite know what a good summary is, so I preferred to stick a very descriptive name for now (`ontology_with_iri`)