### PR TITLE
docs: fix J and Js docstrings

### DIFF
--- a/src/mammos_entity/_entities.py
+++ b/src/mammos_entity/_entities.py
@@ -112,13 +112,13 @@ def Hc(
 def J(
     value: int | float | numpy.typing.ArrayLike = 0, unit: None | str = None
 ) -> mammos_entity.Entity:
-    """Create an Entity representing the magnetic polarisation (Js).
+    """Create an Entity representing the magnetic polarisation (J).
 
     Args:
         value: Numeric value corresponding to  magnetic polarisation. It can also be
             a Numpy array.
-        unit: Unit of measure for the value (e.g., 'A/m'). If omitted, the SI unit
-            from the ontology, i.e. A/m, will be inferred.
+        unit: Unit of measure for the value (e.g., 'J/(A m2)' or 'T'). If omitted,
+            the SI unit from the ontology, i.e. J/(A m2), will be inferred.
 
     Returns:
         An `Entity` object labeled "MagneticPolarisation".
@@ -135,8 +135,8 @@ def Js(
     Args:
         value: Numeric value corresponding to spontaneous magnetic polarisation.
             It can also be a Numpy array.
-        unit: Unit of measure for the value (e.g., 'A/m'). If omitted, the SI unit
-            from the ontology, i.e. A/m, will be inferred.
+        unit: Unit of measure for the value (e.g., 'J/(A m2)' or 'T'). If omitted,
+            the SI unit from the ontology, i.e. 'J/(A m2)', will be inferred.
 
     Returns:
         An `Entity` object labeled "SpontaneousMagneticPolarisation".


### PR DESCRIPTION
Spontaneous Magnetic Polarisation:
- [MaMMoS ontology SpontaneousMagneticPolarisation](https://mammos-project.github.io/MagneticMaterialsOntology/doc/magnetic_material_mammos.html#EMMO_57873439-dfa4-5b74-aec7-d530376ae11c)
- [unit: MagneticFluxDensityUnit in EMMO](https://emmo-repo.github.io/emmo.html#id109)

MagneticPolarisation:
- [EMMO MagneticPolarisation](https://emmo-repo.github.io/emmo.html#magneticpolarisation)
- unit: MagneticFluxDensityUnit in EMMO
