### PR TITLE
Introduce EntityLike generic and runtime validation and conversion

### DIFF
--- a/src/mammos_entity/__init__.py
+++ b/src/mammos_entity/__init__.py
@@ -12,6 +12,8 @@ from mammos_entity._base import Entity
 from mammos_entity._entities import A, B, BHmax, H, Hc, J, Js, Ku, M, Mr, Ms, T, Tc
 from mammos_entity._onto import mammos_ontology
 
+from . import typing
+
 __version__ = importlib.metadata.version(__package__)
 
 
@@ -31,4 +33,5 @@ __all__ = [
     "T",
     "Tc",
     "mammos_ontology",
+    "typing",
 ]

--- a/src/mammos_entity/_base.py
+++ b/src/mammos_entity/_base.py
@@ -8,11 +8,13 @@ includes helper functions for inferring the correct SI units from the ontology.
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated, Generic
 
 import mammos_units as u
 
 from mammos_entity._onto import mammos_ontology
+
+from .typing import _LabelT
 
 if TYPE_CHECKING:
     import astropy.units
@@ -103,7 +105,7 @@ def extract_SI_units(ontology_label: str) -> str | None:
     return si_unit
 
 
-class Entity:
+class Entity(Generic[_LabelT]):
     """Create a quantity (a value and a unit) linked to the EMMO ontology.
 
     Represents a physical property or quantity that is linked to an ontology
@@ -123,6 +125,15 @@ class Entity:
         >>> Tc_K = me.Entity("CurieTemperature", Tc_kK, unit=u.K)
 
     """  # noqa: E501
+
+    def __class_getitem__(cls, label: str):
+        if not isinstance(label, str):
+            return Entity
+        else:
+            return Annotated[
+                Entity,
+                ("EntityLabel", label),  # run-time metadata
+            ]
 
     def __init__(
         self,

--- a/src/mammos_entity/typing.py
+++ b/src/mammos_entity/typing.py
@@ -1,0 +1,89 @@
+"""Custom types for mammos-entity."""
+
+from __future__ import annotations
+
+import inspect
+import typing
+from functools import wraps
+from typing import Annotated, Generic, TypeVar
+
+from mammos_units import Quantity
+from numpy.typing import ArrayLike
+
+import mammos_entity as me
+
+_LabelT = TypeVar("_LabelT", bound=str)
+
+
+class _EntityLike(Generic[_LabelT]):
+    """
+    Allows   EntityLike["my_label"]   in type annotations.
+
+    At static-checking time   EntityLike[...]
+        ==  Entity | numpy.typing.ArrayLike
+
+    At run time the annotation is stored as
+        Annotated[Entity | Quantity | ArrayLike, ("EntityLikeLabel", <label>)]
+    so the label can later be retrieved via reflection.
+    """
+
+    __slots__ = ()
+
+    def __class_getitem__(cls, label: str):
+        if not isinstance(label, str):
+            raise TypeError("EntityLike[...] needs a literal str label")
+        return Annotated[
+            me.Entity | Quantity | ArrayLike,  # what type checkers see
+            ("EntityLabel", label),  # run-time metadata
+        ]
+
+
+# public alias
+EntityLike = _EntityLike  # type: ignore[assignment]
+
+
+def _extract_entitylike_label(annotation) -> str | None:
+    """Extract label of an EntityLike["label"] annotation.
+
+    Return the label of an  EntityLike["label"]  annotation,
+    or  None  if the annotation is something else.
+    """
+    origin = typing.get_origin(annotation)
+    if origin is typing.Annotated:
+        _, *meta = typing.get_args(annotation)
+        for item in meta:
+            if isinstance(item, tuple) and item[:1] == ("EntityLabel",):
+                return typing.cast(str, item[1])
+    return None
+
+
+def runtime_convert_entitylikes(func):
+    """Decorator to conver EntityLike to Entity arguments."""  # noqa: D401
+    sig = inspect.signature(func)
+    # include_extras=True keeps the Annotated metadata we need
+    hints = typing.get_type_hints(func, include_extras=True)
+    param_names = list(sig.parameters)  # positional index → parameter name
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        # --- positional arguments -----------------------------------
+        args = list(args)  # mutable copy
+        for idx, value in enumerate(args):
+            name = param_names[idx]
+            label = _extract_entitylike_label(hints.get(name))
+            if label is not None:
+                args[idx] = me.Entity(label, value)
+
+        # --- keyword arguments --------------------------------------
+        new_kwargs = {}
+        for name, value in kwargs.items():
+            label = _extract_entitylike_label(hints.get(name))
+            if label is not None:
+                new_kwargs[name] = me.Entity(label, value)
+            else:
+                new_kwargs[name] = value
+
+        # call the wrapped function
+        return func(*args, **new_kwargs)
+
+    return wrapper


### PR DESCRIPTION
Before, we have code such as 
```python
def Ms_power(
    Ms: mammos_entity.Entity | astropy.units.Quantity | numpy.typing.ArrayLike,
    power: int
) -> astropy.units.Quantity:
    # type of Ms can be anything
    Ms = me.Ms(Ms)
    return np.power(Ms.q, power)
```

With the proposed changes we can replace this with
```python
from mammos_entity.typing import EntityLike, runtime_convert_entitylikes

@runtime_convert_entitylikes
def Ms_power(
    Ms: EntityLike["SpontaneousMagnetization"],
    power: int
) -> astropy.units.Quantity:
    # decorator guarantees that Ms is an Entity
    return np.power(Ms.q, power)
```

Both functions can be called with the same types of inputs:
```python
# scalars
>>> Ms_power(2, 3)
<Quantity 8. A3 / m3>

# array-like
>>> repr(Ms_power([2, 4], 3))
'<Quantity [ 8., 64.] A3 / m3>'

# Quantity
>>> Ms_power(2 * u.A / u.m, 3)
<Quantity 8. A3 / m3>

# Entity
>>> Ms_power(me.Ms(2, 3)
<Quantity 8. A3 / m3>
```

Code is not ready for a detailed review. I'll have to do some more cleanup first.