### PR TITLE
Define equivalencies in Entity definition

### DIFF
--- a/changes/118.changed.md
+++ b/changes/118.changed.md
@@ -1,0 +1,1 @@
+Definition and methods of `Entity` now rely on a list of set equivalencies, called `mammos_equivalencies`. For the moment, they only include equivalencies between different temperature units.


### PR DESCRIPTION
This allows `Angle` entities to be defined with radians.

Problem: we have to activate the equivalency where before we impose "unit strictness". Is this a behavior we actually want?

For context: [Angle](https://emmo-repo.github.io/versions/1.0.0/emmo.html#angle) is in the ontology a `RatioQuantity`, so dimensionless.

@samjrholt @lang-m @fangohr @swapneelap 