### PR TITLE
Generalise EntityCollection implementation

### DIFF
--- a/changes/122.added.md
+++ b/changes/122.added.md
@@ -1,0 +1,1 @@
+A new property `EntityCollection.entities` that gives access to a dict containing all entities of the collection. This dictionary can be used to access entities whose name is shadowed by a method/property of the EntityCollection class.

--- a/examples/io.ipynb
+++ b/examples/io.ipynb
@@ -723,7 +723,7 @@
     "me.io.entities_to_file(\n",
     "    \"modified_example.csv\",\n",
     "    \"Modified version of `example.csv`.\\nMs has been converted to A/m.\",\n",
-    "    **content._elements_dictionary,\n",
+    "    **content.entities,\n",
     ")\n",
     "pd.read_csv(\"modified_example.csv\", comment=\"#\")"
    ]

--- a/src/mammos_entity/_entity_collection.py
+++ b/src/mammos_entity/_entity_collection.py
@@ -1,5 +1,6 @@
 """EntityCollection class."""
 
+import copy
 import textwrap
 
 import pandas as pd
@@ -20,8 +21,70 @@ class EntityCollection:
             **kwargs : entities to be stored in the collection.
         """
         self.description = description
-        for key, val in kwargs.items():
-            setattr(self, key, val)
+        self._entities = kwargs
+
+    @property
+    def entities(self) -> dict:
+        """Dictionary of entities stored in the collection."""
+        return self._entities
+
+    def __setattr__(self, name, value):
+        """Add new elements to entities dictionary.
+
+        Public name (no leading underscore) becomes part of the ``entities`` dictionary.
+        Private names (at least one leading underscore) are added to the class normally.
+
+        If a property/method with the same name exists it takes precedence and the
+        entity will not be added to ``entities``. Instead, the property assignment is
+        called/the method is overwritten. In such cases add the entity via the dict
+        interface ``collection.entities["name"] = value``.
+        """
+        if name.startswith("_") or hasattr(self.__class__, name):
+            object.__setattr__(self, name, value)
+        else:
+            self._entities[name] = value
+
+    def __getattr__(self, name):
+        """Access entities via dot notation.
+
+        Allow access to entities using ``collection.name`` as a short-hand for
+        ``collection.entities["name"]``.
+
+        If a property/method with the same name exists it gets precedence. In such cases
+        access to the entity is only possible via the ``entities`` dictionary.
+        """
+        try:
+            return self._entities[name]
+        except KeyError:
+            raise AttributeError(name) from None
+
+    def __delattr__(self, name):
+        """Delete element from collection.
+
+        If an entity with ``name`` is in the collections internal dictionary
+        (``entities``) it is removed from that dictionary. If a method with the same
+        name exists, it gets precedence. In such cases delete from the ``entities``
+        dictionary directly by using ``del collection.entities[name]``.
+        """
+        if name.startswith("_") or hasattr(self.__class__, name):
+            object.__delattr__(self, name)
+        elif name in self.entities:
+            del self.entities[name]
+        else:
+            raise AttributeError(
+                f"'{self.__class__.__name__}' object has no attribute '{name}'"
+            )
+
+    def __copy__(self):
+        """Shallow copy of entities."""
+        return self.__class__(description=self.description, **self.entities)
+
+    def __deepcopy__(self, memo):
+        """Deep copy of entities."""
+        entities = {
+            name: copy.deepcopy(entity, memo) for name, entity in self.entities.items()
+        }
+        return self.__class__(description=self.description, **entities)
 
     @property
     def description(self) -> str:
@@ -43,18 +106,10 @@ class EntityCollection:
                 f"Received value: {value} of type: {type(value)}."
             )
 
-    @property
-    def _elements_dictionary(self):
-        """Return a dictionary of all elements stored in the collection."""
-        elements = {k: val for k, val in vars(self).items() if k != "_description"}
-        return elements
-
     def __repr__(self):
         """Show container elements."""
         args = f"description={self.description!r},\n"
-        args += "\n".join(
-            f"{key}={val!r}," for key, val in self._elements_dictionary.items()
-        )
+        args += "\n".join(f"{key}={val!r}," for key, val in self.entities.items())
         return f"{self.__class__.__name__}(\n{textwrap.indent(args, ' ' * 4)}\n)"
 
     def to_dataframe(self, include_units: bool = False):
@@ -79,6 +134,6 @@ class EntityCollection:
         return pd.DataFrame(
             {
                 f"{key}{unit(key) if include_units else ''}": getattr(val, "value", val)
-                for key, val in self._elements_dictionary.items()
+                for key, val in self.entities.items()
             }
         )

--- a/src/mammos_entity/operations.py
+++ b/src/mammos_entity/operations.py
@@ -233,8 +233,8 @@ def merge(
     if "on" in kwargs and kwargs["on"]:
         matching_keys = set(kwargs["on"])
     else:
-        matching_keys = set(preferred_collection.__dict__.keys()) & set(
-            other_collection.__dict__.keys()
+        matching_keys = set(preferred_collection.entities.keys()) & set(
+            other_collection.entities.keys()
         )
     # check compatibility of entities and quantities and homogenize for merging:
     # - fail if the two entity_likes are not compatible

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -52,7 +52,29 @@ def test_EntityCollection_with_description():
         "Magnetization on a grid.", x=[0, 0, 1, 1], y=[0, 1, 0, 1], M=me.M([1, 2, 3, 4])
     )
     assert ec.description == "Magnetization on a grid."
-    assert list(ec._elements_dictionary.keys()) == ["x", "y", "M"]
+    assert list(ec.entities.keys()) == ["x", "y", "M"]
+
+    ec.T = me.T(2)
+    assert list(ec.entities.keys()) == ["x", "y", "M", "T"]
+
+    # changing class elements does not change the entities
+    ec.description = "A new description"
+    assert list(ec.entities.keys()) == ["x", "y", "M", "T"]
+    assert ec.description == "A new description"
+    del ec.T
+    assert list(ec.entities.keys()) == ["x", "y", "M"]
+
+
+def test_EntityCollection_name_clash():
+    ec = me.io.EntityCollection(to_dataframe="value")
+    assert list(ec.entities.keys()) == ["to_dataframe"]
+    assert callable(ec.to_dataframe)
+    assert ec.entities["to_dataframe"] == "value"
+
+    ec.to_dataframe = "missing"
+    assert list(ec.entities.keys()) == ["to_dataframe"]
+    assert ec.to_dataframe == "missing"
+    assert ec.entities["to_dataframe"] == "value"
 
 
 def test_EntityCollection_bad_description():


### PR DESCRIPTION
Store all entities in a dict and allow access either via dot notation or via dict.

Benefits:

- no name clashes
- more robust access to entities only

Closes #107, #119