### PR TITLE
Entity collection from dataframe

### DIFF
--- a/changes/123.added.md
+++ b/changes/123.added.md
@@ -1,0 +1,1 @@
+New methods `EntityCollection.metadata` to extract metadata for all entities in a collection (as dictionary) and `EntityCollection.from_dataframe` to convert a `pandas.DataFrame` + metadata dictionary into an `EntityCollection`.


### PR DESCRIPTION
- users can perform arbitrary manipulation with pandas (e.g. merging collections, appending rows, ...)
- a separate metadata dict makes it convenient for users to re-create an entity collection
- correct handling of unit mismatch, columns with the same name but different meaning, ... is the user's responsibility
- notebook documenting entity collections

Needs #122 

Replaces #110 