### PR TITLE
Added mammos_entity.io._entities_to_hdf5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
   "mammos-units>=0.2.1",
   "numpy<3",
   "pandas>=2",
+  "h5py",
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR introduces functionality to write entities to HDF5-files in a convenient manner, using the already existing `mammos_entity.io.entities_to_file` function.
Everything is explicitly duck-typed. You are welcome to establish more rigorous checking if you'd prefer that.
I made sure to allow for nested inputs with arbitrary depth. To fully utilise the advantages of HDF5-files, `_entities_to_hdf5` also accepts `EntityCollection` and `dict` objects as input. These then create subgroups instead of datasets. This can then repeat over several levels, allowing for a very high degree of flexibility and creating tree-like data structures in the file.

Here an example using the new functionality:

```python
import numpy
import mammos_entity as me
import mammos_units as mu

d = {'Raw Data': {'t': np.random.random(100),
                  'T': np.random.random(100),
                  'H': np.random.random(100),
                  'm': np.random.random(100)},
     'Measurement Data': {'t': me.Entity('Time', np.random.random(100)),
                          'T': me.Entity('ThermodynamicTemperature',
                                         np.random.random(100)),
                          'H': me.Entity('InternalMagneticField',
                                         np.random.random(100)),
                          'M': me.Entity('Magnetization',
                                         np.random.random(100)),},
     'Sample Information': {'Height': 2.1 * mu.mm,
                            'Width' : 2.05 * mu.mm,
                            'Mass':   56.73 * mu.mg,
                            'ID': 'SomeID',
                            'someKey': 12346}
    }

me.entities_to_file('path/to/file.hdf5', 'A helpful description', sample1=d, sample2=d)
```