### PR TITLE
HDF5 support

### DIFF
--- a/changes/147.added.md
+++ b/changes/147.added.md
@@ -1,0 +1,1 @@
+Support for reading and writing HDF5 files.

--- a/examples/hdf5.ipynb
+++ b/examples/hdf5.ipynb
@@ -1,0 +1,809 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9a0fcd93-fe66-444f-8b39-f38b4fe2618d",
+   "metadata": {},
+   "source": [
+    "# NOTE: this should become part of the io notebook, which however requires some cleanup first."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "558d06ae-5513-4688-89e5-9766c02e6cef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import h5py\n",
+    "import mammos_entity as me"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6adc4086-c54a-42ea-870d-9c9c4aeaff9d",
+   "metadata": {},
+   "source": [
+    "## Writing and reading HDF5\n",
+    "\n",
+    "`mammos_entity` provides support for writing entities and entity collections to HDF5 and reading them back in.\n",
+    "\n",
+    "HDF5 provides many options and therefor `mammos_entity` does not prescribe a complete structure. Instead it focusses on storing entity collections and entity likes inside an HDF5 file:\n",
+    "- entity collections are stored as HDF5 groups\n",
+    "- entity likes are stored as HDF5 datasets\n",
+    "\n",
+    "In write mode `mammos_entity` can either create a new file or work on parts of an existing file."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "861020fa-2bed-4641-a915-71ed9e7d89e7",
+   "metadata": {},
+   "source": [
+    "### Single entity\n",
+    "\n",
+    "As a first example we create a single entity with four values an save it to disk:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d2ca5091-f4c3-4715-bb64-a6cce645bc64",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<samp>ThermodynamicTemperature(value=[&nbsp;10.&nbsp;&nbsp;20.&nbsp;&nbsp;50.&nbsp;100.],&nbsp;unit=K)</samp>"
+      ],
+      "text/plain": [
+       "Entity(ontology_label='ThermodynamicTemperature', value=array([ 10.,  20.,  50., 100.]), unit='K')"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "T = me.T([10, 20, 50, 100], \"K\")\n",
+    "T"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fce2bdfc-a8ba-462a-88e6-7be61fb60415",
+   "metadata": {},
+   "source": [
+    "To save it to file we can specify the file name and a name of the dataset storing the entity. A new hdf5 file will be created automatically. If a file with the same name exits it will be overwritten."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "be726381-b3a9-4d8c-9a85-04350dba7e8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "T.to_hdf5(\"test.hdf5\", \"temperature\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf5e2300-e773-4a8b-b23e-971aca7e3ef5",
+   "metadata": {},
+   "source": [
+    "We can inspect the content of the file using [`h5glance`](https://pypi.org/project/h5glance/):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "cbc97e03-f6a3-4b17-b20b-36a1fc7b2451",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[94mtest.hdf5\u001b[0m\n",
+      "└\u001b[1mtemperature\u001b[0m\t[float64: 4]\n",
+      "  └5 attributes:\n",
+      "    ├description: ''\n",
+      "    ├mammos_entity_version: '0.11.1'\n",
+      "    ├ontology_iri: 'https://w3id.org/em...2_86c6_69e26182a17f'\n",
+      "    ├ontology_label: 'ThermodynamicTemperature'\n",
+      "    └unit: 'K'\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "!h5glance --attrs test.hdf5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "adfa9c87-9d33-42c3-9446-2bc60c22004c",
+   "metadata": {},
+   "source": [
+    "We can see that we got a single dataset `temperature` with data of type `float64` and four elements (we don't see the actual values). Furthermore, the temperature dataset contains metedata attributes for description, ontology information, the unit, and the version of `mammos_entity` used to write the dataset.\n",
+    "\n",
+    "We can read the file and get back an entity collection:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c53b3d1b-3e04-4d40-8329-898961d5b76b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "EntityCollection(\n",
+       "    description='',\n",
+       "    temperature=Entity(ontology_label='ThermodynamicTemperature', value=array([ 10.,  20.,  50., 100.]), unit='K'),\n",
+       ")"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "content = me.io.from_hdf5(\"test.hdf5\")\n",
+    "content"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2731f12-f909-4cea-a0c1-204277e10274",
+   "metadata": {},
+   "source": [
+    "We can access the entity using the name we have chosen when saving the file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "30ccb317-bca8-4a6b-b3ad-6bb5999a1041",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<samp>ThermodynamicTemperature(value=[&nbsp;10.&nbsp;&nbsp;20.&nbsp;&nbsp;50.&nbsp;100.],&nbsp;unit=K)</samp>"
+      ],
+      "text/plain": [
+       "Entity(ontology_label='ThermodynamicTemperature', value=array([ 10.,  20.,  50., 100.]), unit='K')"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "content.temperature"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4ac8e10-dcd9-4774-82ff-c31fde9d787c",
+   "metadata": {},
+   "source": [
+    "We can also open the file ourselves and only read a single dataset. We then directly get the entity:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e96cd5d5-6e27-4fde-87fd-dfd69dcbbfc8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ThermodynamicTemperature(value=[ 10.  20.  50. 100.], unit=K)\n"
+     ]
+    }
+   ],
+   "source": [
+    "with h5py.File(\"test.hdf5\") as f:\n",
+    "    print(me.io.from_hdf5(f[\"/temperature\"]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f27b9e6b-cfed-4f45-a205-74122ff32ec0",
+   "metadata": {},
+   "source": [
+    "### Entity collection\n",
+    "\n",
+    "To group together multiple entities we use `EntityCollection`s. For HDF5 `mammos_entity` maps the collection to an HDF5 group."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "5c4b2e19-5362-4d72-a913-da1a405e843e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "EntityCollection(\n",
+       "    description='intrinsic properties',\n",
+       "    Tc=Entity(ontology_label='CurieTemperature', value=800.0, unit='K'),\n",
+       "    Ms=Entity(ontology_label='SpontaneousMagnetization', value=600.0, unit='kA / m'),\n",
+       ")"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collection = me.EntityCollection(\n",
+    "    description=\"intrinsic properties\",\n",
+    "    Tc=me.Tc(800, \"K\"),\n",
+    "    Ms=me.Ms(600, \"kA/m\"),\n",
+    ")\n",
+    "collection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4e9762e-3a85-48ff-8c61-4db5f104aefc",
+   "metadata": {},
+   "source": [
+    "We will show different options writing the collection.\n",
+    "\n",
+    "First, we open the file ourselves and pass the open file object to the `to_hdf5` method, which allows us to append to the previously generated file.\n",
+    "\n",
+    "We pass a name for the group that will store the collection. It will be created automatically and will keep track of the order of the entities in the collection. Each entity of the collection will be stored as a dataset inside the newly created group. The names of these datasets will be the names of the entities in the collection."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "91937cad-a44e-43aa-9777-296cab76bf29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with h5py.File(\"test.hdf5\", \"a\") as f:  # append to the file created before\n",
+    "    collection.to_hdf5(f, \"/properties\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "d3c64139-cac6-4fb8-84c6-4f3c5b582965",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[94mtest.hdf5\u001b[0m\n",
+      "├\u001b[94mproperties\u001b[0m\n",
+      "│ ├2 attributes:\n",
+      "│ │ ├description: 'intrinsic properties'\n",
+      "│ │ └mammos_entity_version: '0.11.1'\n",
+      "│ ├\u001b[1mTc\u001b[0m\t[float64: scalar]\n",
+      "│ │ └4 attributes:\n",
+      "│ │   ├description: ''\n",
+      "│ │   ├ontology_iri: 'https://w3id.org/em...3_a1d6_54c9f778343d'\n",
+      "│ │   ├ontology_label: 'CurieTemperature'\n",
+      "│ │   └unit: 'K'\n",
+      "│ └\u001b[1mMs\u001b[0m\t[float64: scalar]\n",
+      "│   └4 attributes:\n",
+      "│     ├description: ''\n",
+      "│     ├ontology_iri: 'https://w3id.org/em...b-9c9d-6dafaa17ef25'\n",
+      "│     ├ontology_label: 'SpontaneousMagnetization'\n",
+      "│     └unit: 'kA / m'\n",
+      "└\u001b[1mtemperature\u001b[0m\t[float64: 4]\n",
+      "  └5 attributes:\n",
+      "    ├description: ''\n",
+      "    ├mammos_entity_version: '0.11.1'\n",
+      "    ├ontology_iri: 'https://w3id.org/em...2_86c6_69e26182a17f'\n",
+      "    ├ontology_label: 'ThermodynamicTemperature'\n",
+      "    └unit: 'K'\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "!h5glance --attrs test.hdf5"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "5c77b7a0-9231-4644-822b-ed4431b7e5c3",
+   "metadata": {},
+   "source": [
+    "We can see that our HDF5 file now has two top-level elements:\n",
+    "- the dataset `temperature` created in the first step\n",
+    "- the group `properties` with two datasets `Tc` and `Ms` created from the collection. The group attributes contain the collection description and the version of `mammos_entity` used to write the file. The individual entities of the collection do not record that version, as it can be inferred from the group.\n",
+    "\n",
+    "We can read the whole file and get two nested collections:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "d701607d-4bb9-4133-b7e9-ab14578fc206",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "EntityCollection(\n",
+       "    description='',\n",
+       "    properties=EntityCollection(\n",
+       "        description='intrinsic properties',\n",
+       "        Tc=Entity(ontology_label='CurieTemperature', value=800.0, unit='K'),\n",
+       "        Ms=Entity(ontology_label='SpontaneousMagnetization', value=600.0, unit='kA / m'),\n",
+       "    ),\n",
+       "    temperature=Entity(ontology_label='ThermodynamicTemperature', value=array([ 10.,  20.,  50., 100.]), unit='K'),\n",
+       ")"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "me.io.from_hdf5(\"test.hdf5\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "beb32a83-88de-420d-970d-995dcab51d52",
+   "metadata": {},
+   "source": [
+    "We can also open the file first and let mammos_entity only read the group and get a single EntityCollection:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "0a8af2bf-dcab-45f6-980e-b55d1a143366",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EntityCollection(\n",
+      "    description='intrinsic properties',\n",
+      "    Tc=Entity(ontology_label='CurieTemperature', value=800.0, unit='K'),\n",
+      "    Ms=Entity(ontology_label='SpontaneousMagnetization', value=600.0, unit='kA / m'),\n",
+      ")\n"
+     ]
+    }
+   ],
+   "source": [
+    "with h5py.File(\"test.hdf5\") as f:\n",
+    "    print(me.io.from_hdf5(f[\"/properties\"]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2da4d7f-81c8-4b19-ba20-f185106e3948",
+   "metadata": {},
+   "source": [
+    "If we pass the file name instead of the file object the previous file content will be overwritten:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "3b94d5f0-7b11-4fc5-a68f-7370ba284e0d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collection.to_hdf5(\"test.hdf5\", \"/properties-overwritten\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "c50c73d2-e1af-467a-8607-727329d13d21",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[94mtest.hdf5\u001b[0m\n",
+      "└\u001b[94mproperties-overwritten\u001b[0m\n",
+      "  ├2 attributes:\n",
+      "  │ ├description: 'intrinsic properties'\n",
+      "  │ └mammos_entity_version: '0.11.1'\n",
+      "  ├\u001b[1mTc\u001b[0m\t[float64: scalar]\n",
+      "  │ └4 attributes:\n",
+      "  │   ├description: ''\n",
+      "  │   ├ontology_iri: 'https://w3id.org/em...3_a1d6_54c9f778343d'\n",
+      "  │   ├ontology_label: 'CurieTemperature'\n",
+      "  │   └unit: 'K'\n",
+      "  └\u001b[1mMs\u001b[0m\t[float64: scalar]\n",
+      "    └4 attributes:\n",
+      "      ├description: ''\n",
+      "      ├ontology_iri: 'https://w3id.org/em...b-9c9d-6dafaa17ef25'\n",
+      "      ├ontology_label: 'SpontaneousMagnetization'\n",
+      "      └unit: 'kA / m'\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "!h5glance --attrs test.hdf5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82fc5671-4a6b-4ede-96af-48e25fd64cdc",
+   "metadata": {},
+   "source": [
+    "When writing collections the `name` attribute is optional. If not provided, all entities will be added to the file/group root. E.g. when creating a new file all entities and the collection description will be added directly to the root group:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "88cdbd42-8d86-4931-837a-25c34a4c66b7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collection.to_hdf5(\"test.hdf5\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "921ecbff-d9a2-49cf-9608-a571a06e9327",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[94mtest.hdf5\u001b[0m\n",
+      "├2 attributes:\n",
+      "│ ├description: 'intrinsic properties'\n",
+      "│ └mammos_entity_version: '0.11.1'\n",
+      "├\u001b[1mMs\u001b[0m\t[float64: scalar]\n",
+      "│ └4 attributes:\n",
+      "│   ├description: ''\n",
+      "│   ├ontology_iri: 'https://w3id.org/em...b-9c9d-6dafaa17ef25'\n",
+      "│   ├ontology_label: 'SpontaneousMagnetization'\n",
+      "│   └unit: 'kA / m'\n",
+      "└\u001b[1mTc\u001b[0m\t[float64: scalar]\n",
+      "  └4 attributes:\n",
+      "    ├description: ''\n",
+      "    ├ontology_iri: 'https://w3id.org/em...3_a1d6_54c9f778343d'\n",
+      "    ├ontology_label: 'CurieTemperature'\n",
+      "    └unit: 'K'\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "!h5glance --attrs test.hdf5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f063771-ef81-403e-8493-bbc8f66b879a",
+   "metadata": {},
+   "source": [
+    "### Multiple writes\n",
+    "\n",
+    "We can add as many datasets/groups anywhere in the HDF5 file we like. We are also not limited to only writing data with `mammos_entity` and instead can also add other data.\n",
+    "\n",
+    "Appart from the methods shown before there is also a function `me.io.to_hdf5` that can write any entity-like or entity collection to HDF5. The method will automatically store the additional metadata required for EntityCollection/Entity/Quantity as required for reading the file with mammos-entity. The first argument is the data to be written.\n",
+    "\n",
+    "Function and method can be used interchangably."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "a526666b-0104-4dcf-bbdb-c20c3d3690ee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with h5py.File(\"test.hdf5\", \"w\") as f:  # overwrite the file created before\n",
+    "    # store an entity using the function in io\n",
+    "    Hc = me.Hc(300, \"kA/m\")\n",
+    "    me.io.to_hdf5(Hc, f, \"/Hc\")\n",
+    "\n",
+    "    # implicitly create a new group\n",
+    "    me.io.to_hdf5(me.Entity(\"Length\", 5, \"nm\", description=\"edge length x\"), f, \"/geometry/x\")\n",
+    "\n",
+    "    # pass a group instead of a file\n",
+    "    me.Entity(\"Length\", 10, \"nm\", description=\"edge length y\").to_hdf5(f[\"/geometry\"], \"y\")\n",
+    "\n",
+    "    # store a collection using the function in io\n",
+    "    me.io.to_hdf5(collection, f, \"intrinsic properties\")\n",
+    "\n",
+    "    # a quantity added to the collection 'intrinsic properties'\n",
+    "    me.io.to_hdf5(5 * me.units.mm**2, f, \"/intrinsic properties/q\")\n",
+    "\n",
+    "    # additional data, making use of other options available in h5py.File.create_dataset\n",
+    "    f.create_dataset(\"raw data\", data=[0.1, 0.2, 0.3, 0.5, 0.9], dtype=\"float32\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "c038255a-e45f-4b1a-8ca3-7d7be8ac831d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[94mtest.hdf5\u001b[0m\n",
+      "├\u001b[1mHc\u001b[0m\t[float64: scalar]\n",
+      "│ └5 attributes:\n",
+      "│   ├description: ''\n",
+      "│   ├mammos_entity_version: '0.11.1'\n",
+      "│   ├ontology_iri: 'https://w3id.org/em...8-886b-fa6d6052ce98'\n",
+      "│   ├ontology_label: 'CoercivityHcExternal'\n",
+      "│   └unit: 'kA / m'\n",
+      "├\u001b[94mgeometry\u001b[0m\n",
+      "│ ├\u001b[1mx\u001b[0m\t[float64: scalar]\n",
+      "│ │ └5 attributes:\n",
+      "│ │   ├description: 'edge length x'\n",
+      "│ │   ├mammos_entity_version: '0.11.1'\n",
+      "│ │   ├ontology_iri: 'https://w3id.org/em...1_b27e_2e88db027bac'\n",
+      "│ │   ├ontology_label: 'Length'\n",
+      "│ │   └unit: 'nm'\n",
+      "│ └\u001b[1my\u001b[0m\t[float64: scalar]\n",
+      "│   └5 attributes:\n",
+      "│     ├description: 'edge length y'\n",
+      "│     ├mammos_entity_version: '0.11.1'\n",
+      "│     ├ontology_iri: 'https://w3id.org/em...1_b27e_2e88db027bac'\n",
+      "│     ├ontology_label: 'Length'\n",
+      "│     └unit: 'nm'\n",
+      "├\u001b[94mintrinsic properties\u001b[0m\n",
+      "│ ├2 attributes:\n",
+      "│ │ ├description: 'intrinsic properties'\n",
+      "│ │ └mammos_entity_version: '0.11.1'\n",
+      "│ ├\u001b[1mTc\u001b[0m\t[float64: scalar]\n",
+      "│ │ └4 attributes:\n",
+      "│ │   ├description: ''\n",
+      "│ │   ├ontology_iri: 'https://w3id.org/em...3_a1d6_54c9f778343d'\n",
+      "│ │   ├ontology_label: 'CurieTemperature'\n",
+      "│ │   └unit: 'K'\n",
+      "│ ├\u001b[1mMs\u001b[0m\t[float64: scalar]\n",
+      "│ │ └4 attributes:\n",
+      "│ │   ├description: ''\n",
+      "│ │   ├ontology_iri: 'https://w3id.org/em...b-9c9d-6dafaa17ef25'\n",
+      "│ │   ├ontology_label: 'SpontaneousMagnetization'\n",
+      "│ │   └unit: 'kA / m'\n",
+      "│ └\u001b[1mq\u001b[0m\t[float64: scalar]\n",
+      "│   └2 attributes:\n",
+      "│     ├mammos_entity_version: '0.11.1'\n",
+      "│     └unit: 'mm2'\n",
+      "└\u001b[1mraw data\u001b[0m\t[float32: 5]\n"
+     ]
+    }
+   ],
+   "source": [
+    "!h5glance --attrs test.hdf5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "560994bf-12cf-4312-86ac-2acca3c3af13",
+   "metadata": {},
+   "source": [
+    "In the attributes we can see that the version of `mammos_entity` is recorded for each outermost object written explicitely with `to_hdf5`. For example, the quantity `q` records the version despite being part of the group `intrinsic properties`, the group `geometry` does not have that version because it has only been created implicitly as parent of entity `x`.\n",
+    "\n",
+    "We can read the whole file as a single nested entity collection. It will read all groups/datasets and choose the most appropriate type:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "a7f35204-e9b7-43f9-b877-f475aa351c32",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "EntityCollection(\n",
+       "    description='',\n",
+       "    Hc=Entity(ontology_label='CoercivityHcExternal', value=300.0, unit='kA / m'),\n",
+       "    geometry=EntityCollection(\n",
+       "        description='',\n",
+       "        x=Entity(ontology_label='Length', value=5.0, unit='nm', description='edge length x'),\n",
+       "        y=Entity(ontology_label='Length', value=10.0, unit='nm', description='edge length y'),\n",
+       "    ),\n",
+       "    intrinsic properties=EntityCollection(\n",
+       "        description='intrinsic properties',\n",
+       "        Tc=Entity(ontology_label='CurieTemperature', value=800.0, unit='K'),\n",
+       "        Ms=Entity(ontology_label='SpontaneousMagnetization', value=600.0, unit='kA / m'),\n",
+       "        q=<Quantity 5. mm2>,\n",
+       "    ),\n",
+       "    raw data=array([0.1, 0.2, 0.3, 0.5, 0.9], dtype=float32),\n",
+       ")"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "with h5py.File(\"test.hdf5\") as f:\n",
+    "    content = me.io.from_hdf5(f)\n",
+    "\n",
+    "content"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6b9e07e1-12a1-4bf5-8f95-6a00f2ebfa8b",
+   "metadata": {},
+   "source": [
+    "We can access individual elements of the nested structure:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "2f837308-9580-4ec3-be5d-aa9e46e798c3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<samp>CoercivityHcExternal(value=300.0,&nbsp;unit=kA&nbsp;/&nbsp;m)</samp>"
+      ],
+      "text/plain": [
+       "Entity(ontology_label='CoercivityHcExternal', value=300.0, unit='kA / m')"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "content.Hc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "6fb7113c-a543-4ea3-bb83-f35ecc1660b5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<samp>Length(value=5.0,&nbsp;unit=nm,&nbsp;description='edge&nbsp;length&nbsp;x')</samp>"
+      ],
+      "text/plain": [
+       "Entity(ontology_label='Length', value=5.0, unit='nm', description='edge length x')"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "content.geometry.x"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2bddafc-bb74-47d4-82a5-ad5b83cf6ded",
+   "metadata": {},
+   "source": [
+    "Some of the names are not valid python variables, so we have to use the dict interface of EntityCollection:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "ee0660ba-b978-405b-a8d6-096f5a32db72",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<samp>CurieTemperature(value=800.0,&nbsp;unit=K)</samp>"
+      ],
+      "text/plain": [
+       "Entity(ontology_label='CurieTemperature', value=800.0, unit='K')"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "content[\"intrinsic properties\"].Tc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "a0669cd2-74a1-4952-ac00-c2144bdc12c6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$5 \\; \\mathrm{mm^{2}}$"
+      ],
+      "text/plain": [
+       "<Quantity 5. mm2>"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "content[\"intrinsic properties\"].q"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "86032a7c-d12d-406b-ab1c-9dd8aeea609b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0.1, 0.2, 0.3, 0.5, 0.9], dtype=float32)"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "content[\"raw data\"]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
   "emmontopy>=0.8",
+  "h5glance>=0.9",  # required for the tutorial
+  "h5py>=3.13",  # TODO we would like >= 3.14 (improved string handling) but esys-escript conflicts with that
   "mammos-units>=0.2.1",
   "numpy<3",
   "pandas>=2",

--- a/src/mammos_entity/_entity.py
+++ b/src/mammos_entity/_entity.py
@@ -12,10 +12,14 @@ from typing import TYPE_CHECKING
 
 import mammos_units as u
 
+import mammos_entity as me
 from mammos_entity._ontology import mammos_ontology
 
 if TYPE_CHECKING:
+    import os
+
     import astropy.units
+    import h5py
     import mammos_units
     import numpy.typing
     import owlready2
@@ -344,3 +348,28 @@ class Entity:
     def _repr_html_(self) -> str:
         html_str = str(self).replace("\n", "<br>").replace(" ", "&nbsp;")
         return f"<samp>{html_str}</samp>"
+
+    def to_hdf5(
+        self, base: h5py.File | h5py.Group | str | os.PathLike, name: str
+    ) -> h5py.Dataset | None:
+        """Write an entity to an HDF5 dataset.
+
+        The value is added as data; ontology_label, iri, unit and description are
+        written to the dataset attributes.
+
+        Args:
+            base: If it is an open HDF5 file or a group in an HDF5 file, data will be
+                added to it as new dataset. If it is a str or PathLike a new HDF5 file
+                with the given name will be created. If a file with that name exists
+                already, it will be overwritten without notice.
+            name: Name for the newly created dataset. If an element with that name
+                exists already in `base` the function will fail.
+
+        Returns:
+            If `base` is an open `File` or `Group` the newly created dataset. If `base`
+            is a file name nothing is returned (because the file created internally will
+            be closed before the function returns).
+
+        .. seealso:: :py:func:`mammos_entity.io.to_hdf5`
+        """
+        return me.io.to_hdf5(self, base, name)

--- a/src/mammos_entity/_entity_collection.py
+++ b/src/mammos_entity/_entity_collection.py
@@ -14,9 +14,11 @@ from . import units as u
 
 if TYPE_CHECKING:
     import collections.abc
+    import os
     import pathlib
 
     import astropy
+    import h5py
     import numpy.typing
 
     import mammos_entity
@@ -364,3 +366,30 @@ class EntityCollection:
             entities[name] = elem
 
         return cls(description=description, **entities)
+
+    def to_hdf5(
+        self, base: h5py.File | h5py.Group | str | os.PathLike, name: str | None = None
+    ) -> h5py.Group | None:
+        """Write a collection to an HDF5 group.
+
+        Entities of the collection become datasets in the group. The collection
+        description is added to the group attributes.
+
+        Args:
+            base: If it is an open HDF5 file or a group in an HDF5 file, data will be
+                added to it as new group. If it is a str or PathLike a new HDF5 file
+                with the given name will be created. If a file with that name exists
+                already, it will be overwritten without notice.
+            name: Name for the newly created group. If an element with that name
+                exists already in `base` the function will fail. If `name` is ``None``
+                entities of the collection will be added directly to `base` and the
+                collection description will be added to `base` attributes.
+
+        Returns:
+            If `base` is an open `File` or `Group` the newly created group. If `base` is
+            a file name nothing is returned (because the file created internally will be
+            closed before the function returns).
+
+        .. seealso:: :py:func:`mammos_entity.io.to_hdf5`
+        """
+        return me.io.to_hdf5(self, base, name)

--- a/src/mammos_entity/io.py
+++ b/src/mammos_entity/io.py
@@ -214,11 +214,13 @@ import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import h5py
 import mammos_units as u
 import numpy as np
 import pandas as pd
 import yaml
 
+import mammos_entity as me
 from mammos_entity._entity import Entity
 from mammos_entity._entity_collection import EntityCollection
 
@@ -635,5 +637,149 @@ def _check_iri(entity: mammos_entity.Entity, iri: str) -> None:
         )
 
 
+def to_hdf5(
+    data: mammos_entity.EntityLike | mammos_entity.EntityCollection,
+    base: h5py.File | h5py.Group | str | os.PathLike,
+    name: str | None,
+) -> h5py.Dataset | h5py.Group | None:
+    """Write data to HDF5.
+
+    :py:class:`~mammos_entity.EntityLike` data is written as HDF5 dataset. Metadata is
+    added to the attributes depending on the precise type:
+
+    - :py:class:`~mammos_entity.Entity`: ontology_label, ontology_iri, unit and
+      description
+    - :py:class:`~astropy.units.Quantity`: unit
+    - anything else: no metadata
+
+    An :py:class:`~mammos_entity.EntityCollection` is written as HDF5 group. Entities
+    in the collection become HDF5 datasets of that group, collections in the collection
+    become subgroups. The collection description is added to the group attributes.
+
+    Group/dataset attributes can in addition have a key ``mammos_entity_version`` that
+    records the version of `mammos_entity` used to write that data. This key is only
+    added to the outermost object created when calling the function (excluding
+    intermediate groups that may be created when passing a longer path for `name`), i.e.
+    when writing a collection only the corresponding group has the attribute, elements
+    of the collection (entity-likes or nested collections) do not repeat that metadata.
+    When making use of this metadata the innermost occurence of the key is authorative.
+
+    Args:
+        data: Data written to the file.
+        base: If it is an open HDF5 file or a group in an HDF5 file, data will be
+            added to it, either as new group or as dataset(s). If it is a str or
+            PathLike a new HDF5 file with the given name will be created. If a file with
+            that name exists already, it will be overwritten without notice.
+        name: Name for the newly created group or dataset. If an element with that name
+            exists already in `base` the function will fail. When passing an
+            EntitityCollection as `data`, `name` is optional. If not provided the
+            entities of the collection will be added directly to `base` and the
+            collection description will be added to `base` attributes.
+
+    Returns:
+        If `base` is an open `File` or `Group` the newly created group or dataset. If
+        `base` is a file name nothing is returned (because the file created internally
+        will be closed before the function returns).
+
+    """
+    return _to_hdf5(data, base, name)
+
+
+def _to_hdf5(
+    data: mammos_entity.EntityLike | mammos_entity.EntityCollection,
+    base: h5py.File | h5py.Group | str | os.PathLike,
+    name: str | None,
+    record_mammos_entity_version: bool = True,
+) -> h5py.Dataset | h5py.Group | None:
+    """Internal implementation with additional options required for recursion.
+
+    Args:
+        data: <see public function>
+        base: <see public function>
+        name: <see public function>
+        record_mammos_entity_version: add mammos_entity version to group/dataset
+            attributes.
+    """
+    if isinstance(base, str | os.PathLike):
+        with h5py.File(base, "w") as f:
+            _to_hdf5(data, f, name)
+            return
+
+    if isinstance(data, EntityCollection):
+        group = base.create_group(name, track_order=True) if name is not None else base
+        group.attrs["description"] = data.description
+        if record_mammos_entity_version:
+            group.attrs["mammos_entity_version"] = me.__version__
+        for name, entity_like in data:
+            _to_hdf5(entity_like, group, name, record_mammos_entity_version=False)
+        return group
+    else:
+        if name is None:
+            raise ValueError("'name' must not be None when 'data' is entity-like.")
+        if isinstance(data, Entity):
+            dset = base.create_dataset(name, data=data.value)
+            dset.attrs["ontology_label"] = data.ontology_label
+            dset.attrs["ontology_iri"] = data.ontology.iri
+            dset.attrs["unit"] = str(data.unit)
+            dset.attrs["description"] = data.description
+        elif isinstance(data, u.Quantity):
+            dset = base.create_dataset(name, data=data.value)
+            dset.attrs["unit"] = str(data.unit)
+        else:
+            dset = base.create_dataset(name, data=data)
+        if record_mammos_entity_version:
+            dset.attrs["mammos_entity_version"] = me.__version__
+        return dset
+
+
+def from_hdf5(
+    element: h5py.File | h5py.Group | h5py.Dataset | str | os.PathLike,
+    decode_bytes: bool = True,
+) -> mammos_entity.EntityLike | mammos_entity.EntityCollection:
+    """Read HDF5 file, group or dataset and convert to Entity or EntityCollection.
+
+    Datasets are converted to :py:class:`~mammos_entity.Entity`,
+    :py:class:`~astropy.units.Quantity`, or a numpy array or other builtin datatype
+    depending on their associated metadata and shape.
+
+    Groups are converted to :py:class:`~mammos_entity.EntityCollection`. Arbitrary
+    nesting of groups is supported and produces nested collections.
+
+    Args:
+        element: If it is a `str` or `PathLike` the entire file is read from disk. If
+            it is an open HDF5 `File`, `Group` or `Dataset` only that part of the file
+            is read.
+        decode_bytes: If ``True`` data of all datasets of type object is converted to
+            strings (if scalar) or numpy arrays of strings (if vector). If ``False`` the
+            bytes object (or array of bytes objects) is returned.
+
+    Returns:
+        All data in the given HDF5 file/group/dataset as (nested) EntityCollection
+       and/or EntityLike object.
+    """
+    if isinstance(element, str | os.PathLike):
+        with h5py.File(element) as f:
+            return from_hdf5(f, decode_bytes)
+    elif isinstance(element, h5py.File | h5py.Group):
+        collection = EntityCollection(description=element.attrs.get("description", ""))
+        for name, sub in element.items():
+            collection[name] = from_hdf5(sub)
+        return collection
+    elif "ontology_label" in element.attrs:
+        return Entity(
+            ontology_label=element.attrs["ontology_label"],
+            value=element[()],
+            unit=element.attrs["unit"],
+            description=element.attrs["description"],
+        )
+    elif "unit" in element.attrs:
+        return u.Quantity(element[()], element.attrs["unit"])
+    else:
+        if element.dtype == "object" and decode_bytes:
+            element = element.asstr()
+        data = element[()]
+        return data
+
+
 # hide deprecated functions in documentation
-__all__ = ["entities_to_file", "entities_from_file"]
+__all__ = ["entities_to_file", "entities_from_file", "to_hdf5", "from_hdf5"]

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,6 +1,8 @@
 import os
 import textwrap
+from pathlib import Path
 
+import h5py
 import mammos_units as u
 import numpy as np
 import pandas as pd
@@ -425,3 +427,176 @@ def test_wrong_iri(tmp_path, extension: str):
 
     with pytest.raises(RuntimeError, match="Incompatible IRI for Entity"):
         me.io.entities_from_file(filename)
+
+
+def test_entity_to_hdf5():
+    f = h5py.File.in_memory()
+
+    # write to dataset
+    T = me.T(100, "K")
+    T.to_hdf5(f, "T")
+    assert "T" in f
+    assert f["T"][()] == T.value
+    assert f["T"].attrs["unit"] == T.unit
+    assert f["T"].attrs["ontology_label"] == T.ontology_label
+    assert f["T"].attrs["ontology_iri"] == T.ontology.iri
+    assert f["T"].attrs["mammos_entity_version"] == me.__version__
+    assert me.io.from_hdf5(f["T"]) == T
+
+    # write to dataset in newly created group
+    Ms = me.Ms([[10, 20], [30, 40.0]], description="test")
+    me.io.to_hdf5(Ms, f, "/base/Ms")
+    assert "base" in f
+    assert "Ms" in f["base"]
+    assert (f["/base/Ms"][()] == Ms.value).all()
+    assert f["/base/Ms"].attrs["description"] == Ms.description
+    assert "mammos_entity_version" not in f["/base"].attrs
+    assert f["/base/Ms"].attrs["mammos_entity_version"] == me.__version__
+    assert me.io.from_hdf5(f["/base/Ms"]) == Ms
+
+    # write to existing group
+    Ms.to_hdf5(f["/base"], "Ms2")
+    assert me.io.from_hdf5(f["/base/Ms2"]) == Ms
+
+    # write to newly created subgroup inside existing group
+    me.io.to_hdf5(Ms, f["/base"], "sub/Ms")
+    assert me.io.from_hdf5(f["/base/sub/Ms"]) == Ms
+
+    with pytest.raises(ValueError, match="name already exists"):
+        me.io.to_hdf5(Ms, f, "/base/Ms")
+
+    f.close()
+
+
+def test_entity_collection_to_hdf5():
+    f = h5py.File.in_memory()
+
+    col = me.EntityCollection(
+        description="intrinsic properties",
+        Ms=me.Ms([300, 250, 200], "kA/m"),
+        T=me.T([50, 100, 200]),
+        Tc=me.Tc(600, "K"),
+    )
+
+    # write group and create base group on the fly
+    group = col.to_hdf5(f, "/sample1/properties")
+    assert f["/sample1/properties"].attrs["description"] == col.description
+    assert f["/sample1/properties"].attrs["mammos_entity_version"] == me.__version__
+    assert "mammos_entity_version" not in f["/sample1"].attrs
+    assert "mammos_entity_version" not in f["/sample1/properties/Ms"].attrs
+    assert "mammos_entity_version" not in f["/sample1/properties/T"].attrs
+    assert "mammos_entity_version" not in f["/sample1/properties/Tc"].attrs
+    assert list(f["/sample1/properties"]) == ["Ms", "T", "Tc"]
+
+    me.io.to_hdf5(col, f["/sample1"], "properties_repeated")
+    assert (f["/sample1/properties_repeated/Ms"][()] == col.Ms.value).all()
+
+    col_read = me.io.from_hdf5(f["/sample1/properties"])
+    assert isinstance(col_read, me.EntityCollection)
+    assert col_read.description == col.description
+    assert [name for name, _entity in col_read] == ["Ms", "T", "Tc"]
+    assert col_read.Ms == col.Ms
+    assert col_read.T == col.T
+    assert col_read.Tc == col.Tc
+
+    # users have full control over additional hdf5 features
+    group["Ms"].dims[0].label = "T"
+    group["T"].make_scale("T")
+    group["Ms"].dims[0].attach_scale(group["T"])
+    assert group["Ms"].dims[0]["T"] == group["T"]
+    # this does not affect reading (but the additional information is lost)
+    col_read = me.io.from_hdf5(f["/sample1/properties"])
+    assert col_read.Ms == col.Ms
+    assert col_read.T == col.T
+
+    f.close()
+
+
+def test_nested_entity_collection_to_hdf5():
+    f = h5py.File.in_memory()
+
+    col = me.EntityCollection(
+        description="intrinsic properties",
+        Ms=me.Ms([300, 250, 200], "kA/m"),
+        T=me.T([50, 100, 200]),
+        Tc=me.Tc(600, "K"),
+    )
+    sample = me.EntityCollection(
+        description="produced by student",
+        properties=col,
+        edge_length=[1, 2, 3] * me.units.mm,
+        measurement_device="device X",
+    )
+
+    # write two nested collections using both api options
+    sample.to_hdf5(f, "sample1")
+    me.io.to_hdf5(sample, f, "sample2")
+
+    assert f["/sample1"].attrs["mammos_entity_version"] == me.__version__
+    assert "mammos_entity_version" not in f["/sample1/properties"].attrs
+    assert "mammos_entity_version" not in f["/sample1/properties/Ms"].attrs
+
+    sample_read = me.io.from_hdf5(f["sample1"])
+    assert "properties" in sample_read
+    assert "edge_length" in sample_read
+    assert "measurement_device" in sample_read
+
+    assert me.io.from_hdf5(
+        f["sample2/measurement_device"], decode_bytes=False
+    ) == sample.measurement_device.encode("utf8")
+
+    # we can also read the whole file and get one extra level of nesting
+    full_content = me.io.from_hdf5(f)
+
+    assert isinstance(full_content, me.EntityCollection)
+    assert full_content.description == ""
+    assert full_content.sample1.description == sample.description
+    assert full_content.sample2.description == sample.description
+
+    # we can access everything via the nesting
+    assert full_content.sample1.properties.Tc.value == 600
+
+    # add additional inner collection/entities to sample2 to test mammos_entity_version
+    # propagation
+    col.to_hdf5(f, "sample2/extra")
+    me.io.to_hdf5(me.A(), f, "sample2/a")
+    me.io.to_hdf5(me.A(), f, "sample2/extra/a")
+
+    assert f["/sample2/extra"].attrs["mammos_entity_version"] == me.__version__
+    assert "mammos_entity_version" not in f["/sample2/extra/Ms"].attrs
+    assert "mammos_entity_version" not in f["/sample2/extra/T"].attrs
+    assert "mammos_entity_version" not in f["/sample2/extra/Tc"].attrs
+    assert f["/sample2/a"].attrs["mammos_entity_version"] == me.__version__
+    assert f["/sample2/extra/a"].attrs["mammos_entity_version"] == me.__version__
+
+    f.close()
+
+
+def test_to_new_hdf5_file(tmp_path: Path):
+    T = me.T()
+    T.to_hdf5(tmp_path / "test.h5", "entity")
+
+    assert (tmp_path / "test.h5").is_file()
+
+    content = me.io.from_hdf5(tmp_path / "test.h5")
+    assert isinstance(content, me.EntityCollection)
+    assert content.entity == T
+
+    # overwrite with a collection
+    c = me.EntityCollection(Tc=me.Tc(), Ms=me.Ms(), description="abc")
+    c.to_hdf5(str(tmp_path / "test.h5"))
+
+    content2 = me.io.from_hdf5(str(tmp_path / "test.h5"))
+
+    assert isinstance(content2, me.EntityCollection)
+    assert content2.description == "abc"
+    # Note for the following check: we do not create a new group and therefor, insertion
+    # order is irrelevant (h5py by default does not track insertion order). This changes
+    # when we create a group manually, where insertion order is tracked
+    assert [name for name, _ in content2] == ["Ms", "Tc"]
+    assert content2.Ms == me.Ms()
+    assert content2.Tc == me.Tc()
+
+    c.to_hdf5(str(tmp_path / "test.h5"), "ordered")
+    content3 = me.io.from_hdf5(str(tmp_path / "test.h5"))
+    assert [name for name, _ in content3.ordered] == ["Tc", "Ms"]


### PR DESCRIPTION
~~Implements a simplified version of #140 (as proposed in https://github.com/MaMMoS-project/mammos-entity/pull/140#issuecomment-3884762728)~~

Support for writing and reading Entities and EntityCollections as HDF5 datasets and HDF5 groups.

Open points for follow-up PRs
- record ontology version
- allow writing/reading HDF5 with generic `entities_to_file`/`entities_from_file`

Closes #140 