### PR TITLE
Nested colletion to dataframe

### DIFF
--- a/changes/158.fixed.md
+++ b/changes/158.fixed.md
@@ -1,0 +1,1 @@
+Block conversion of nested collection to dataframe. Before, the elements of the inner collection were added as dataframe rows.

--- a/src/mammos_entity/_entity_collection.py
+++ b/src/mammos_entity/_entity_collection.py
@@ -242,6 +242,8 @@ class EntityCollection:
         Args:
             include_units: If true, include units in the dataframe column names.
         """
+        if any(isinstance(element, EntityCollection) for _name, element in self):
+            raise ValueError("Nested collections cannot be converted to dataframe.")
 
         def unit(key: str) -> str:
             """Get unit for element key.
@@ -469,7 +471,7 @@ class EntityCollection:
 
         """  # noqa: E501
         if any(isinstance(element, EntityCollection) for _name, element in self):
-            raise RuntimeError("Nested collections cannot be saved to CSV.")
+            raise ValueError("Nested collections cannot be saved to CSV.")
 
         ontology_labels = []
         descriptions = []

--- a/tests/test_entity_collection.py
+++ b/tests/test_entity_collection.py
@@ -144,6 +144,16 @@ def test_to_dataframe_scalar():
     assert df.equals(ec.to_dataframe())
 
 
+def test_to_dataframe_unsupported():
+    col1 = me.EntityCollection(Ms=me.Ms([[1, 2], [3, 4]]))
+    with pytest.raises(ValueError):
+        col1.to_dataframe()
+
+    col2 = me.EntityCollection(Ms=me.Ms(), sub=me.EntityCollection())
+    with pytest.raises(ValueError, match="Nested collection"):
+        col2.to_dataframe()
+
+
 def test_from_dataframe():
     data = pd.DataFrame({"M": [1, 2], "T": [3, 4], "l_q": [5, 6], "x": [7, 8]})
     metadata = {


### PR DESCRIPTION
Currently we do not check for nested collections in the dataframe conversion. The conversion works by coincidence if the length of entities in the outer collection matches the number of entities in the inner collection.

Converting nested collections to dataframe is generally not well defined and we therefore explicitly disallow it.