### PR TITLE
Make mammos_entity.typing module public

### DIFF
--- a/changes/162.added.md
+++ b/changes/162.added.md
@@ -1,0 +1,1 @@
+New module `mammos_entity.typing` with a type alias `EntityLike` for static type annotations.

--- a/src/mammos_entity/__init__.py
+++ b/src/mammos_entity/__init__.py
@@ -31,7 +31,6 @@ from mammos_entity._factory import (
 )
 from mammos_entity._ontology import mammos_ontology, search_labels
 from mammos_entity._read_files import from_csv, from_hdf5, from_yaml
-from mammos_entity._typing import EntityLike
 
 from . import operations
 
@@ -41,7 +40,6 @@ __version__ = importlib.metadata.version(__package__)
 __all__ = [
     "Entity",
     "EntityCollection",
-    "EntityLike",
     "A",
     "B",
     "BHmax",

--- a/src/mammos_entity/_entity_collection.py
+++ b/src/mammos_entity/_entity_collection.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     import numpy.typing
 
     import mammos_entity
+    import mammos_entity.typing
 
 
 class EntityCollection:
@@ -777,7 +778,7 @@ class EntityCollection:
 
 
 def _to_hdf5(
-    data: mammos_entity.EntityLike | mammos_entity.EntityCollection,
+    data: mammos_entity.typing.EntityLike | mammos_entity.EntityCollection,
     base: h5py.File | h5py.Group | str | os.PathLike,
     name: str | None,
     record_mammos_entity_version: bool = True,

--- a/src/mammos_entity/_read_files.py
+++ b/src/mammos_entity/_read_files.py
@@ -16,6 +16,7 @@ from mammos_entity._entity_collection import EntityCollection
 
 if TYPE_CHECKING:
     import mammos_entity
+    import mammos_entity.typing
 
 
 def from_csv(filename: str | Path) -> mammos_entity.EntityCollection:
@@ -196,7 +197,7 @@ def _check_iri(entity: mammos_entity.Entity, iri: str) -> None:
 def from_hdf5(
     element: h5py.File | h5py.Group | h5py.Dataset | str | os.PathLike,
     decode_bytes: bool = True,
-) -> mammos_entity.EntityLike | mammos_entity.EntityCollection:
+) -> mammos_entity.typing.EntityLike | mammos_entity.EntityCollection:
     """Read HDF5 file, group or dataset and convert to Entity or EntityCollection.
 
     Datasets are converted to :py:class:`~mammos_entity.Entity`,

--- a/src/mammos_entity/typing.py
+++ b/src/mammos_entity/typing.py
@@ -1,3 +1,5 @@
+"""Type aliases for static type annotations."""
+
 from typing import TypeAlias
 
 import astropy.units


### PR DESCRIPTION
The `typing` module is not imported into the `mammos_entity` namespace as users generally do not interact with it.

Closes #153 