### PR TITLE
add switch to `prefLabel` for any given `ontology_label`

### DIFF
--- a/changes/170.fixed.md
+++ b/changes/170.fixed.md
@@ -1,0 +1,1 @@
+Creating entities with secondary labels will from now on produce entities with the `prefLabel` as their `ontology_label`.

--- a/src/mammos_entity/_entity.py
+++ b/src/mammos_entity/_entity.py
@@ -15,7 +15,7 @@ import h5py
 import mammos_units as u
 
 import mammos_entity as me
-from mammos_entity._ontology import mammos_ontology
+from mammos_entity._ontology import mammos_ontology, search_labels
 
 if TYPE_CHECKING:
     import astropy.units
@@ -158,11 +158,18 @@ class Entity:
         if unit is None and isinstance(value, u.Quantity):
             unit = value.unit
 
+        # extract prefLabel
+        label_matches = search_labels(ontology_label, auto_wildcard=False)
+        if len(label_matches) == 0:
+            raise ValueError(f"No entity found with label {ontology_label}")
+        else:
+            pref_label = label_matches[0]
+
         with u.set_enabled_aliases(
             # filtering units we do not want as default
             {"Cel": "K", "mCel": "K", "har": "m2"}
         ):
-            si_unit = u.Unit(_extract_SI_units(ontology_label))
+            si_unit = u.Unit(_extract_SI_units(pref_label))
 
         if unit is None:
             # the user does not specify a unit:
@@ -178,14 +185,14 @@ class Entity:
                 if not si_unit.is_equivalent(unit):
                     raise u.UnitConversionError(
                         f"The unit '{unit}' is not equivalent to the unit of"
-                        f" {ontology_label} '{si_unit}'"
+                        f" {pref_label} '{si_unit}'"
                     )
 
         comp_unit = u.Unit(unit if unit else "")
 
         with u.set_enabled_equivalencies(mammos_equivalencies):
             self._quantity = u.Quantity(value=value, unit=comp_unit)
-        self._ontology_label = ontology_label
+        self._ontology_label = pref_label
 
     @property
     def description(self) -> str:

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -208,6 +208,14 @@ def test_all_labels_ontology(ontology_element):
     me.Entity(ontology_element.prefLabel[0], 42)
 
 
+def test_switch_to_pref_label():
+    """Test the switch to prefLabel instead of given one."""
+    assert me.Entity("Ms").ontology_label == "SpontaneousMagnetization"
+    assert me.Entity("K1").ontology_label == "MagnetocrystallineAnisotropyConstantK1"
+    assert me.Entity("A").ontology_label == "ExchangeStiffnessConstant"
+    assert me.Entity("Js").ontology_label == "SpontaneousMagneticPolarisation"
+
+
 def test_ontology_information_mammos():
     """Test ontology label and IRI for an Entity in the MaMMoS ontology."""
     e = me.Entity("ExternalMagneticField")


### PR DESCRIPTION
Even creating `Entity("Ms")` will return now a `Entity("SpontaneousMagnetization")`.