### PR TITLE
TO COMPLICATED - REJECTED: Generic Entity and EntityLike, decorator for runtime conversion

### DIFF
--- a/src/mammos_entity/__init__.py
+++ b/src/mammos_entity/__init__.py
@@ -10,6 +10,7 @@ import importlib.metadata
 
 import mammos_units as units
 
+from mammos_entity._decorators import convert_entity_likes
 from mammos_entity._entity import Entity
 from mammos_entity._entity_collection import EntityCollection
 from mammos_entity._factory import (
@@ -32,7 +33,7 @@ from mammos_entity._factory import (
 from mammos_entity._ontology import mammos_ontology, search_labels
 from mammos_entity._read_files import from_csv, from_hdf5, from_yaml
 
-from . import operations
+from . import operations, typing
 
 __version__ = importlib.metadata.version(__package__)
 
@@ -40,6 +41,7 @@ __version__ = importlib.metadata.version(__package__)
 __all__ = [
     "Entity",
     "EntityCollection",
+    "convert_entity_likes",
     "A",
     "B",
     "BHmax",
@@ -57,6 +59,7 @@ __all__ = [
     "Tc",
     "mammos_ontology",
     "operations",
+    "typing",
     "search_labels",
     "units",
     "from_csv",

--- a/src/mammos_entity/_decorators.py
+++ b/src/mammos_entity/_decorators.py
@@ -1,0 +1,325 @@
+"""Decorators for annotation-driven entity conversion."""
+
+from __future__ import annotations
+
+import inspect
+import types
+from collections.abc import Callable
+from functools import wraps
+from typing import (
+    Any,
+    Literal,
+    ParamSpec,
+    TypeVar,
+    Union,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
+
+import astropy.units
+
+from mammos_entity._entity import Entity
+from mammos_entity._ontology import mammos_ontology
+
+P = ParamSpec("P")
+R = TypeVar("R")
+_ParameterContract = tuple[tuple[str, ...], bool]
+
+
+def convert_entity_likes(func: Callable[P, R]) -> Callable[P, R]:
+    """Convert entity-like parameters to entities.
+
+    Supported parameter annotations:
+
+    - ``EntityLike[Literal["Label"]]``
+    - ``EntityLike[Literal["Label1", "Label2", ...]]``
+    - Optional form of the above, e.g. ``EntityLike[Literal["Label"]] | None``
+    - The same scalar contracts for ``*args`` and ``**kwargs`` values
+
+    If multiple labels are listed in ``Literal[...]``, the first label is canonical for
+    input conversion.
+
+    Notes:
+    - Return annotations and return values are ignored by this decorator.
+    - Container annotations such as ``list[EntityLike[...]]`` and
+      ``tuple[EntityLike[...], ...]`` are intentionally unsupported. For these use
+      :py:func:`mammos_entity.operations.concat_flat` explicitly.
+
+    Args:
+        func: Callable to decorate.
+
+    Returns:
+        Wrapped callable with converted inputs.
+
+    Examples:
+        Basic conversion:
+
+        >>> from typing import Literal
+        >>> import mammos_entity as me
+        >>> import mammos_units as u
+        >>> @me.convert_entity_likes
+        ... def f(t: me.typing.EntityLike[Literal["ThermodynamicTemperature"]]):
+        ...     return t
+        >>> isinstance(f(300 * u.K), me.Entity)
+        True
+
+        Optional passthrough:
+
+        >>> @me.convert_entity_likes
+        ... def f_opt(
+        ...     t: me.typing.EntityLike[Literal["ThermodynamicTemperature"]] | None,
+        ... ):
+        ...     return t
+        >>> f_opt(None) is None
+        True
+
+        Var-positional conversion:
+
+        >>> @me.convert_entity_likes
+        ... def f_args(
+        ...     *t: me.typing.EntityLike[
+        ...         Literal["ThermodynamicTemperature", "CurieTemperature"]
+        ...     ],
+        ... ):
+        ...     return t
+        >>> all(
+        ...     x.ontology_label == "ThermodynamicTemperature"
+        ...     for x in f_args(300, me.Entity("CurieTemperature", 301))
+        ... )
+        True
+
+    """
+    signature = inspect.signature(func)
+    annotations = get_type_hints(func, include_extras=True)
+    converters: dict[str, _ParameterContract] = {}
+
+    for name, annotation in annotations.items():
+        if name == "return":
+            continue
+        contract = _parse_parameter_contract(annotation)
+        if contract is None:
+            continue
+        _check_labels_exist(contract[0])
+        converters[name] = contract
+
+    @wraps(func)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        bound_arguments = signature.bind(*args, **kwargs)
+        bound_arguments.apply_defaults()
+
+        for parameter_name, contract in converters.items():
+            if parameter_name not in bound_arguments.arguments:
+                continue
+
+            parameter = signature.parameters[parameter_name]
+            parameter_value = bound_arguments.arguments[parameter_name]
+
+            if parameter.kind is inspect.Parameter.VAR_POSITIONAL:
+                bound_arguments.arguments[parameter_name] = tuple(
+                    _convert_parameter_value(
+                        item, contract, f"{parameter_name}[{index}]"
+                    )
+                    for index, item in enumerate(parameter_value)
+                )
+            elif parameter.kind is inspect.Parameter.VAR_KEYWORD:
+                bound_arguments.arguments[parameter_name] = {
+                    key: _convert_parameter_value(
+                        value, contract, f"{parameter_name}.{key}"
+                    )
+                    for key, value in parameter_value.items()
+                }
+            else:
+                bound_arguments.arguments[parameter_name] = _convert_parameter_value(
+                    parameter_value, contract, parameter_name
+                )
+
+        return func(*bound_arguments.args, **bound_arguments.kwargs)
+
+    return wrapper
+
+
+def _parse_parameter_contract(annotation: Any) -> _ParameterContract | None:
+    """Parse one parameter annotation into a scalar conversion contract."""
+    # Normalize optional annotations once so downstream parsing only handles the
+    # non-None part of the contract.
+    inner_annotation, allow_none = _split_optional(annotation)
+    origin = get_origin(inner_annotation)
+
+    if origin in (list, tuple):
+        if _contains_entity_like_annotation(inner_annotation):
+            raise TypeError(
+                "Container annotations are unsupported in convert_entity_likes. "
+                "Use operations.concat_flat for list/tuple entity-like data."
+            )
+        return None
+
+    if origin is dict:
+        if _contains_entity_like_annotation(inner_annotation):
+            raise TypeError(
+                "unsupported annotation for convert_entity_likes parameter."
+            )
+        return None
+
+    if origin in (Union, types.UnionType):
+        # EntityLike[...] is represented at runtime as a union of concrete types.
+        # We therefore infer an EntityLike-style contract by finding one Entity[...]
+        # branch (labels) plus a Quantity branch.
+        labels: tuple[str, ...] | None = None
+        non_entity_args: list[Any] = []
+        for argument in get_args(inner_annotation):
+            argument_labels = _labels_from_entity_annotation(argument)
+            if argument_labels is not None:
+                if labels is None:
+                    labels = argument_labels
+                else:
+                    # Top-level union-of-Entity annotations is documentation only.
+                    return None
+                continue
+
+            argument_origin = get_origin(argument)
+            if argument_origin in (list, tuple):
+                raise TypeError(
+                    "Container annotations are unsupported in convert_entity_likes. "
+                    "Use operations.concat_flat for list/tuple entity-like data."
+                )
+            if argument_origin is dict:
+                raise TypeError(
+                    "unsupported annotation for convert_entity_likes parameter."
+                )
+            non_entity_args.append(argument)
+
+        if labels is not None:
+            # Convert only EntityLike-style unions.
+            if astropy.units.Quantity not in non_entity_args:
+                return None
+            return labels, allow_none
+
+        if _contains_entity_like_annotation(inner_annotation):
+            raise TypeError(
+                "unsupported annotation for convert_entity_likes parameter."
+            )
+        return None
+
+    labels = _labels_from_entity_like_annotation(inner_annotation)
+    if labels is not None:
+        return labels, allow_none
+
+    return None
+
+
+def _split_optional(annotation: Any) -> tuple[Any, bool]:
+    """Split ``T | None`` into ``(T, True)``.
+
+    If ``None`` appears in a larger union, it is removed and the remaining union is
+    returned with ``True``.
+    """
+    origin = get_origin(annotation)
+    if origin not in (Union, types.UnionType):
+        return annotation, False
+
+    args = get_args(annotation)
+    non_none_args = [argument for argument in args if argument is not type(None)]  # noqa: E721
+    has_none = len(non_none_args) != len(args)
+
+    if not has_none:
+        return annotation, False
+    if not non_none_args:
+        return annotation, True
+    if len(non_none_args) == 1:
+        return non_none_args[0], True
+
+    # Rebuild the union with ``|`` so later logic can continue using ``get_origin``
+    # / ``get_args`` consistently on a non-optional annotation.
+    merged_annotation = non_none_args[0]
+    for argument in non_none_args[1:]:
+        merged_annotation = merged_annotation | argument
+    return merged_annotation, True
+
+
+def _labels_from_entity_like_annotation(annotation: Any) -> tuple[str, ...] | None:
+    """Extract ontology labels from scalar entity-like annotations."""
+    # EntityLike aliases resolve to unions containing exactly one Entity[Literal[...]]
+    # branch plus a Quantity branch.
+    if get_origin(annotation) not in (Union, types.UnionType):
+        return None
+
+    labels: tuple[str, ...] | None = None
+    has_quantity = False
+    for argument in get_args(annotation):
+        argument_labels = _labels_from_entity_annotation(argument)
+        if argument_labels is not None:
+            if labels is None:
+                labels = argument_labels
+            continue
+        if argument is astropy.units.Quantity:
+            has_quantity = True
+
+    if labels is not None and has_quantity:
+        return labels
+    return None
+
+
+def _contains_entity_like_annotation(annotation: Any) -> bool:
+    """Return ``True`` if an annotation tree contains entity-like contracts."""
+    if _labels_from_entity_like_annotation(annotation) is not None:
+        return True
+
+    origin = get_origin(annotation)
+    if origin in (list, tuple, dict, Union, types.UnionType):
+        for argument in get_args(annotation):
+            if argument is Ellipsis:
+                continue
+            if _contains_entity_like_annotation(argument):
+                return True
+    return False
+
+
+def _labels_from_entity_annotation(annotation: Any) -> tuple[str, ...] | None:
+    """Extract ontology labels from ``Entity[Literal[...]]`` annotations."""
+    if get_origin(annotation) is not Entity:
+        return None
+
+    annotation_args = get_args(annotation)
+    if len(annotation_args) != 1:
+        raise TypeError("Entity[...] annotation requires exactly one type argument.")
+
+    literal_argument = annotation_args[0]
+    if get_origin(literal_argument) is not Literal:
+        raise TypeError("Entity[...] annotations must use Literal[...] labels.")
+
+    labels = get_args(literal_argument)
+    if not labels:
+        raise TypeError("Literal[...] for Entity annotations must not be empty.")
+    if not all(isinstance(label, str) for label in labels):
+        raise TypeError("Entity labels must be string literals.")
+    return labels
+
+
+def _check_labels_exist(labels: tuple[str, ...]) -> None:
+    """Validate that all labels exist in the ontology."""
+    for label in labels:
+        mammos_ontology.get_by_label(label)
+
+
+def _convert_parameter_value(
+    value: Any, contract: _ParameterContract, parameter_name: str
+) -> Entity | None:
+    """Convert one scalar parameter value according to one parsed contract."""
+    labels, allow_none = contract
+
+    if value is None and allow_none:
+        return None
+
+    canonical_label = labels[0]
+    if isinstance(value, Entity):
+        if value.ontology_label not in labels:
+            raise TypeError(
+                f"Argument '{parameter_name}' expects one of {labels}, "
+                f"got '{value.ontology_label}'."
+            )
+        if value.ontology_label == canonical_label:
+            return value
+        return Entity(canonical_label, value.quantity, description=value.description)
+
+    return Entity(canonical_label, value)

--- a/src/mammos_entity/_entity.py
+++ b/src/mammos_entity/_entity.py
@@ -9,13 +9,14 @@ from __future__ import annotations
 
 import os
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Generic
 
 import h5py
 import mammos_units as u
 
 import mammos_entity as me
 from mammos_entity._ontology import mammos_ontology
+from mammos_entity._typevars import OntologyLabelT
 
 if TYPE_CHECKING:
     import astropy.units
@@ -113,7 +114,7 @@ def _extract_SI_units(ontology_label: str) -> str:
     return si_unit
 
 
-class Entity:
+class Entity(Generic[OntologyLabelT]):
     """Create a quantity (a value and a unit) linked to the EMMO ontology.
 
     Represents a physical property or quantity that is linked to an ontology

--- a/src/mammos_entity/_typevars.py
+++ b/src/mammos_entity/_typevars.py
@@ -1,0 +1,9 @@
+"""Private type variable definitions shared across typing modules."""
+
+from typing import TypeVar
+
+#: Type variable bound to ontology labels represented as strings.
+#:
+#: This is the shared label parameter used by generic type hints such as
+#: :py:class:`mammos_entity.Entity` and :py:data:`mammos_entity.typing.EntityLike`.
+OntologyLabelT = TypeVar("OntologyLabelT", bound=str)

--- a/src/mammos_entity/typing.py
+++ b/src/mammos_entity/typing.py
@@ -6,9 +6,20 @@ import astropy.units
 import numpy.typing
 
 import mammos_entity
+from mammos_entity._typevars import OntologyLabelT as _OntologyLabelT
+
+#: Type variable for ontology labels used in public typing annotations.
+#:
+#: In user-facing annotations this is typically specialized with
+#: ``typing.Literal[...]``, for example ``Entity[Literal["CurieTemperature"]]``.
+OntologyLabelT = _OntologyLabelT
+
+__all__ = ["OntologyLabelT", "EntityLike"]
 
 EntityLike: TypeAlias = (
-    mammos_entity.Entity | astropy.units.Quantity | numpy.typing.ArrayLike
+    mammos_entity.Entity[OntologyLabelT]
+    | astropy.units.Quantity
+    | numpy.typing.ArrayLike
 )
 """Any object that can be interpreted as an entity. Besides entities, this includes
 quantities and raw numbers (scalar or array-like). The latter two are interpreted as

--- a/tests/test_convert_entity_likes.py
+++ b/tests/test_convert_entity_likes.py
@@ -1,0 +1,200 @@
+from typing import Literal
+
+import mammos_units as u
+import pytest
+
+import mammos_entity as me
+
+LABEL = "ThermodynamicTemperature"
+ALT_LABEL = "CurieTemperature"
+
+
+# Intended use
+
+
+def test_convert_entity_likes_converts_quantity_input():
+    @me.convert_entity_likes
+    def identity(
+        temperature: me.typing.EntityLike[Literal[LABEL]],
+    ):
+        assert isinstance(temperature, me.Entity)
+        assert temperature.ontology_label == LABEL
+        return temperature
+
+    result = identity(300 * u.K)
+    assert isinstance(result, me.Entity)
+    assert result.ontology_label == LABEL
+    assert u.allclose(result.q, 300 * u.K)
+
+
+def test_convert_entity_likes_uses_first_label_as_canonical():
+    @me.convert_entity_likes
+    def identity(
+        temperature: me.typing.EntityLike[Literal[LABEL, ALT_LABEL]],
+    ):
+        return temperature
+
+    result = identity(me.Entity(ALT_LABEL, 300 * u.K, description="input"))
+    assert isinstance(result, me.Entity)
+    assert result.ontology_label == LABEL
+    assert result.description == "input"
+    assert u.allclose(result.q, 300 * u.K)
+
+
+def test_convert_entity_likes_passes_none_through_for_optional_annotation():
+    @me.convert_entity_likes
+    def identity(
+        temperature: me.typing.EntityLike[Literal[LABEL]] | None,
+    ):
+        return temperature
+
+    assert identity(None) is None
+
+
+def test_convert_entity_likes_converts_optional_non_none_values():
+    @me.convert_entity_likes
+    def identity(
+        temperature: me.typing.EntityLike[Literal[LABEL]] | None,
+    ):
+        return temperature
+
+    result = identity(300)
+    assert isinstance(result, me.Entity)
+    assert result.ontology_label == LABEL
+    assert u.allclose(result.q, 300 * u.K)
+
+
+def test_convert_entity_likes_accepts_matching_return_entity():
+    @me.convert_entity_likes
+    def as_curie_temperature(
+        temperature: me.typing.EntityLike[Literal[LABEL]],
+    ) -> me.Entity[Literal[ALT_LABEL]]:
+        return me.Entity(ALT_LABEL, temperature.q)
+
+    result = as_curie_temperature(300)
+    assert isinstance(result, me.Entity)
+    assert result.ontology_label == ALT_LABEL
+    assert u.allclose(result.q, 300 * u.K)
+
+
+def test_convert_entity_likes_ignores_return_annotation_validation():
+    @me.convert_entity_likes
+    def as_curie_temperature(
+        temperature: me.typing.EntityLike[Literal[LABEL]],
+    ) -> me.Entity[Literal[ALT_LABEL]]:
+        return temperature.q
+
+    result = as_curie_temperature(300)
+    assert u.allclose(result, 300 * u.K)
+
+
+def test_convert_entity_likes_allows_dict_return_with_entity_annotation():
+    @me.convert_entity_likes
+    def as_dict(
+        temperature: me.typing.EntityLike[Literal[LABEL]],
+    ) -> dict[str, me.Entity[Literal[LABEL]]]:
+        return {"temperature": temperature}
+
+    result = as_dict(300)
+    assert isinstance(result, dict)
+    assert "temperature" in result
+    assert isinstance(result["temperature"], me.Entity)
+    assert result["temperature"].ontology_label == LABEL
+
+
+def test_convert_entity_likes_supports_var_positional_annotation():
+    @me.convert_entity_likes
+    def identity(*temperature: me.typing.EntityLike[Literal[LABEL, ALT_LABEL]]):
+        return temperature
+
+    result = identity(300, 301 * u.K, me.Entity(ALT_LABEL, 302 * u.K))
+    assert isinstance(result, tuple)
+    assert all(isinstance(item, me.Entity) for item in result)
+    assert all(item.ontology_label == LABEL for item in result)
+    assert u.allclose(
+        u.Quantity([item.value for item in result], u.K),
+        [300, 301, 302] * u.K,
+    )
+
+
+def test_convert_entity_likes_supports_var_keyword_annotation():
+    @me.convert_entity_likes
+    def identity(**temperature: me.typing.EntityLike[Literal[LABEL, ALT_LABEL]]):
+        return temperature
+
+    result = identity(a=300, b=301 * u.K, c=me.Entity(ALT_LABEL, 302 * u.K))
+    assert isinstance(result, dict)
+    assert set(result) == {"a", "b", "c"}
+    assert all(isinstance(item, me.Entity) for item in result.values())
+    assert all(item.ontology_label == LABEL for item in result.values())
+    assert u.allclose(
+        u.Quantity([result[key].value for key in ("a", "b", "c")], u.K),
+        [300, 301, 302] * u.K,
+    )
+
+
+# Misuse and unsupported contracts
+
+
+def test_convert_entity_likes_rejects_incompatible_entity_label():
+    @me.convert_entity_likes
+    def identity(
+        temperature: me.typing.EntityLike[Literal[LABEL]],
+    ):
+        return temperature
+
+    with pytest.raises(TypeError, match="expects one of"):
+        identity(me.Entity("ExternalMagneticField", 1))
+
+
+def test_convert_entity_likes_rejects_list_annotation():
+    with pytest.raises(TypeError, match="concat_flat"):
+
+        @me.convert_entity_likes
+        def identity(
+            temperature: list[me.typing.EntityLike[Literal[LABEL]]],
+        ):
+            return temperature
+
+
+def test_convert_entity_likes_rejects_tuple_annotation():
+    with pytest.raises(TypeError, match="concat_flat"):
+
+        @me.convert_entity_likes
+        def identity(
+            temperature: tuple[
+                me.typing.EntityLike[Literal[LABEL]],
+                ...,
+            ],
+        ):
+            return temperature
+
+
+def test_convert_entity_likes_rejects_dict_annotation():
+    with pytest.raises(TypeError, match="unsupported"):
+
+        @me.convert_entity_likes
+        def identity(
+            temperature: dict[str, me.typing.EntityLike[Literal[LABEL]]],
+        ):
+            return temperature
+
+
+def test_convert_entity_likes_rejects_mixed_union_annotation():
+    with pytest.raises(TypeError, match="unsupported"):
+
+        @me.convert_entity_likes
+        def identity(
+            temperature: me.typing.EntityLike[Literal[LABEL]] | dict[str, float],
+        ):
+            return temperature
+
+
+def test_convert_entity_likes_requires_literal_labels_for_parameter():
+    with pytest.raises(TypeError, match="Literal"):
+
+        @me.convert_entity_likes
+        def identity(
+            temperature: me.typing.EntityLike[str],
+        ):
+            return temperature

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,0 +1,28 @@
+from typing import Literal, get_args, get_origin
+
+import mammos_entity as me
+
+
+def test_ontology_label_typevar_exported_in_typing_module():
+    assert hasattr(me.typing, "OntologyLabelT")
+
+
+def test_entity_annotation_is_generic():
+    annotation = me.Entity[Literal["CurieTemperature"]]
+    assert get_origin(annotation) is me.Entity
+    assert get_args(get_args(annotation)[0]) == ("CurieTemperature",)
+
+
+def test_entity_like_annotation_is_generic():
+    annotation = me.typing.EntityLike[
+        Literal["ThermodynamicTemperature", "CurieTemperature"]
+    ]
+    entity_annotation = next(
+        argument
+        for argument in get_args(annotation)
+        if get_origin(argument) is me.Entity
+    )
+    assert get_args(get_args(entity_annotation)[0]) == (
+        "ThermodynamicTemperature",
+        "CurieTemperature",
+    )


### PR DESCRIPTION
This PR introduces Entity and EntityLike generics and a decorator to at runtime convert EntityLikes to Entities in function arguments.

Reviewing it with Sam we decided that it is too complicated for our purposes but keeping it on a branch should we ever need it later could be useful.

Generated-by: OpenAI Codex