### PR TITLE
Entity collection derived classes

### DIFF
--- a/src/mammos_entity/_entity.py
+++ b/src/mammos_entity/_entity.py
@@ -694,3 +694,22 @@ def _to_entity(
         return me.Entity(ontology_label, value, unit)
     else:
         return me.Entity(ontology_label, value)
+
+
+def ensure_entity(required_label: str, **kwargs: mammos_entity.Entity) -> None:
+    """Ensure that object is an entity of the required type (ontology label)."""
+    if len(kwargs) != 1:
+        raise RuntimeError(
+            f"Exactly one entity must be passed as keyword argument, got {len(kwargs)}."
+        )
+    arg_name, entity = kwargs.popitem()
+    if not isinstance(entity, Entity):
+        raise TypeError(
+            f"Argument {arg_name}: expected type 'mammos_entity.Entity', "
+            f"got '{type(entity).__module__}.{type(entity).__name__}'"
+        )
+    if entity.ontology_label != required_label:
+        raise ValueError(
+            f"Argument {arg_name}: expected entity '{required_label}', "
+            f"got '{entity.ontology_label}'"
+        )


### PR DESCRIPTION
Add a new private helper function to check that an object is an entity with the correct type. This function can be used to simplify EntityCollection subclassing, which requires checks for all entity keyword arguments.