### PR TITLE
Fix `search_labels("")`

### DIFF
--- a/changes/224.fixed.md
+++ b/changes/224.fixed.md
@@ -1,0 +1,1 @@
+Fixed logic of the function `mammos_entity.search_labels`. Now it is possible to run `search_labels("")` to get all possible the ontology labels.

--- a/src/mammos_entity/_ontology.py
+++ b/src/mammos_entity/_ontology.py
@@ -89,4 +89,8 @@ def search_labels(text: str, auto_wildcard: bool = True) -> list[str]:
     match_by_prefLabel = set(mammos_ontology.search(prefLabel=label))
     match_by_altLabel = set(mammos_ontology.search(altLabel=label))
     possible_things = match_by_label | match_by_prefLabel | match_by_altLabel
-    return sorted(str(thing.prefLabel[0]) for thing in possible_things)
+    return sorted(
+        str(thing.prefLabel[0])
+        for thing in possible_things
+        if hasattr(thing, "prefLabel")
+    )

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -41,3 +41,16 @@ def test_problematic_labels():
     `altLabel`, `prefLabel`. The function `search_labels` should fix this behaviour.
     """
     assert search_labels("Status") == ["Status", "hasStatus"]
+
+
+def test_empty_label():
+    """Test querying for all possible entity labels.
+
+    We test that the labels of some highly used entities appear when searching for
+    all possible labels.
+    """
+    all_labels = search_labels("")
+    assert "SpontaneousMagnetization" in all_labels
+    assert "ExchangeStiffnessConstant" in all_labels
+    assert "MaximumEnergyProduct" in all_labels
+    assert "CurieTemperature" in all_labels


### PR DESCRIPTION
Closes #223 

For some unclear reason, it turns out that the object `emmo.EMMO_799c067b_083f_4365_9452_1f1433b03676` does not have a `prefLabel`. We know its label should be `SIQuantityDatatype` and we obtain this object with `mammos_entity.mammos_ontology.SIQuantityDatatype`.

This object is in the set `set(mammos_ontology.search(prefLabel=""))` but weirdly it does not have a prefLabel. It seems to be the only entity with this issue:
```python
>>> for thing in mammos_ontology.search(prefLabel="**"):
        if not hasattr(thing, "prefLabel"):
            print(thing)
emmo.EMMO_799c067b_083f_4365_9452_1f1433b03676
```

This is probably a problem from EMMO or from owlready2 (for finding such entity), but to make our package more robust I have added a check to only allow entities with a `prefLabel`.