### PR TITLE
Allow 'description' as name of an entity-like in an EntityCollection

### DIFF
--- a/changes/235.changed.md
+++ b/changes/235.changed.md
@@ -1,0 +1,1 @@
+The name `description` is now allowed as key for an entity-like in an EntityCollection.

--- a/examples/entity-collection.ipynb
+++ b/examples/entity-collection.ipynb
@@ -167,6 +167,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "58d6b1d7-ebef-49be-868a-acf2d41ae3c6",
+   "metadata": {},
+   "source": [
+    ":::{danger}\n",
+    "While assigning an entity `collection.description` directly would raise an error, defining members with the same name of a method is possible and it would lead to re-defining the method as an attribute. This method would make such attribute invisible to the `EntityCollection`, so the dictionary-style access is the only way to manage such cases.\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "b31ec754-ee4e-45fe-9259-1943f76ef7e7",
    "metadata": {},
    "source": [

--- a/examples/entity-collection.ipynb
+++ b/examples/entity-collection.ipynb
@@ -162,7 +162,7 @@
    "id": "ad76657c-024a-46fd-a34e-0629b8728274",
    "metadata": {},
    "source": [
-    "Defining an entity with the name `description` is not allowed."
+    "Defining/accessing an entity with the name `description` is only supported via the dictionary-style access."
    ]
   },
   {
@@ -653,8 +653,7 @@
     {
      "data": {
       "text/plain": [
-       "{'description': 'Some random test data.\\n\\nDescriptions can have multiple lines.',\n",
-       " 'Tc': {'ontology_label': 'CurieTemperature', 'unit': 'K', 'description': ''},\n",
+       "{'Tc': {'ontology_label': 'CurieTemperature', 'unit': 'K', 'description': ''},\n",
        " 'Ms': {'unit': 'kA / m'},\n",
        " 'A': {}}"
       ]
@@ -692,7 +691,7 @@
      "data": {
       "text/plain": [
        "EntityCollection(\n",
-       "    description='Some random test data.\\n\\nDescriptions can have multiple lines.',\n",
+       "    description='',\n",
        "    Tc=Entity(ontology_label='CurieTemperature', value=array([ 10., 100.]), unit='K'),\n",
        "    Ms=<Quantity [400., 500.] kA / m>,\n",
        "    A=array([8.e-12, 9.e-12]),\n",
@@ -748,7 +747,7 @@
      "data": {
       "text/plain": [
        "EntityCollection(\n",
-       "    description='Some random test data.\\n\\nDescriptions can have multiple lines.',\n",
+       "    description='',\n",
        "    Tc=Entity(ontology_label='CurieTemperature', value=array([ 10., 100.]), unit='K'),\n",
        "    Ms=Entity(ontology_label='SpontaneousMagnetization', value=array([400., 500.]), unit='kA / m'),\n",
        "    A=array([1.6e-11, 1.8e-11]),\n",

--- a/src/mammos_entity/_entity_collection.py
+++ b/src/mammos_entity/_entity_collection.py
@@ -43,12 +43,12 @@ class EntityCollection:
     is a valid Python name and no property/method of EntityCollection shadows the
     entity. The dictionary interface does not have these limitations.
 
-    Entities can have arbitrary string names. Entities passed as keyword arguments when
-    creating the collection must have valid Python names. Entities with other names can
-    be added after the collection has been created using the dictonary interface (item
-    assignment). Similarly, an entity with key ``description`` can only be added via
-    item assignment. Entities with names starting with an underscore can only be
-    accessed via the dictionary interface.
+    Collection members (also called entities) can have arbitrary string names. Entities
+    passed as keyword arguments whens creating the collection must have valid Python names.
+    Entities with other names can be added after the collection has been created using the
+    dictonary interface (item assignment). Similarly, an entity with key ``description``
+    can only be added via item assignment. Entities with names starting with an underscore
+    can only be accessed via the dictionary interface.
 
     Examples:
         >>> import mammos_entity as me

--- a/src/mammos_entity/_entity_collection.py
+++ b/src/mammos_entity/_entity_collection.py
@@ -43,9 +43,12 @@ class EntityCollection:
     is a valid Python name and no property/method of EntityCollection shadows the
     entity. The dictionary interface does not have these limitations.
 
-    Entities can have arbitrary string names, with the exception that
-    ``description`` is not allowed. Entities passed as keyword arguments when creating
-    the collection must have valid Python names.
+    Entities can have arbitrary string names. Entities passed as keyword arguments when
+    creating the collection must have valid Python names. Entities with other names can
+    be added after the collection has been created using the dictonary interface (item
+    assignment). Similarly, an entity with key ``description`` can only be added via
+    item assignment. Entities with names starting with an underscore can only be
+    accessed via the dictionary interface.
 
     Examples:
         >>> import mammos_entity as me
@@ -92,6 +95,16 @@ class EntityCollection:
         >>> list(collection)
         [('Ms', Entity(ontology_label='SpontaneousMagnetization', value=np.float64(0.0), unit='A / m')), ('A', [1, 2, 3])]
 
+        An entity with key ``description`` can only be set/accessed via the
+        dictionary-like interface as it collides with the `description` property of the
+        collection:
+
+        >>> collection["description"] = ["An entity-like", "with key description"]
+        >>> collection.description
+        'A description'
+        >>> collection["description"]
+        ['An entity-like', 'with key description']
+
     """  # noqa: E501
 
     def __init__(
@@ -122,8 +135,6 @@ class EntityCollection:
             raise TypeError(
                 f"Name must be a string, received {key!r} ({type(key).__name__})."
             )
-        if key == "description":
-            raise KeyError("'description' is not allowed as entity name.")
         self._entities[key] = value
 
     def __delitem__(self, key: str) -> None:
@@ -204,14 +215,18 @@ class EntityCollection:
 
     def __copy__(self):
         """Shallow copy of entities."""
-        return self.__class__(description=self.description, **self._entities)
+        collection = self.__class__(description=self.description)
+        for name, entity_like in self:
+            collection[name] = entity_like
+        return collection
 
     def __deepcopy__(self, memo):
         """Deep copy of entities."""
-        entities = {
-            name: copy.deepcopy(entity, memo) for name, entity in self._entities.items()
-        }
-        return self.__class__(description=self.description, **entities)
+        collection = self.__class__(description=self.description)
+        for name, entity_like in self:
+            collection[name] = copy.deepcopy(entity_like, memo)
+
+        return collection
 
     @property
     def description(self) -> str:
@@ -254,7 +269,7 @@ class EntityCollection:
             Returns:
                 A string " (unit)" if the element has a unit, otherwise an empty string.
             """
-            unit = getattr(getattr(self, key), "unit", None)
+            unit = getattr(self[key], "unit", None)
             if unit and str(unit):
                 return f" ({unit!s})"
             else:
@@ -269,7 +284,7 @@ class EntityCollection:
             }
         )
 
-    def metadata(self) -> dict[str, str | dict[str, str]]:
+    def metadata(self) -> dict[str, dict[str, str]]:
         """Get entity metadata as dictionary.
 
         This method creates a dictionary containing metadata for all entities in the
@@ -281,18 +296,18 @@ class EntityCollection:
         - key ``unit`` if the attribute is a quantity
         - an empty dictionary otherwise
 
-        In addition there is one key-value pair ``description`` for the collection
-        description.
-
         Examples:
             >>> import mammos_entity as me
             >>> import mammos_units as u
             >>> col = me.EntityCollection("The description", Tc=me.Tc(), x=1 * u.m, a=0)
             >>> col.metadata()
-            {'description': 'The description', 'Tc': {'ontology_label': 'CurieTemperature', 'unit': 'K', 'description': ''}, 'x': {'unit': 'm'}, 'a': {}}
+            {'Tc': {'ontology_label': 'CurieTemperature', 'unit': 'K', 'description': ''}, 'x': {'unit': 'm'}, 'a': {}}
 
+        .. version-changed:: 0.14.0
+           The collection description has been removed from the metadata to allow the
+           name ``description`` as key for an entity-like.
         """  # noqa: E501
-        result = {"description": self.description}
+        result = {}
         for name, entity_like in self._entities.items():
             element = {}
             if isinstance(entity_like, me.Entity):
@@ -307,7 +322,10 @@ class EntityCollection:
 
     @classmethod
     def from_dataframe(
-        cls, dataframe: pandas.DataFrame, metadata: dict[str, dict]
+        cls,
+        dataframe: pandas.DataFrame,
+        metadata: dict[str, dict],
+        description: str = "",
     ) -> mammos_entity.EntityCollection:
         """Create EntityCollection from dataframe and metadata.
 
@@ -329,9 +347,9 @@ class EntityCollection:
                 ``description`` for an :py:class:`~mammos_entity.Entity` are however
                 optional. If not present, default units from the ontology and an empty
                 description are used.
+            description: Description of the entity collection.
         """
         metadata = copy.deepcopy(metadata)  # do not modify the user's metadata dict
-        description = metadata.pop("description", "")
         if missing_keys := set(dataframe.columns) - set(metadata):
             raise ValueError(
                 f"Entity_Metadata is missing for columns: {', '.join(missing_keys)}"
@@ -341,7 +359,7 @@ class EntityCollection:
                 f"Entity_Metadata is missing for columns: {', '.join(missing_keys)}"
             )
 
-        entities = {}
+        collection = cls(description=description)
         for name in metadata:
             value = dataframe[name].to_numpy()
             if len(value) == 1:
@@ -361,9 +379,9 @@ class EntityCollection:
                 )
             else:
                 elem = value
-            entities[name] = elem
+            collection[name] = elem
 
-        return cls(description=description, **entities)
+        return collection
 
     def to_csv(self, filename: str | os.PathLike) -> None:
         r"""Write collection to CSV file.

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -35,6 +35,7 @@ def test_write_read_csv(tmp_path):
         comments=["Some comment", "Some other comment", "A third comment"],
     )
     collection["the length"] = me.Entity("Length", [1, 2, 3])
+    collection["description"] = me.Entity("Length", [0, 0, 1])
     collection.to_csv(tmp_path / "example.csv")
 
     read_data = me.from_csv(tmp_path / "example.csv")
@@ -51,6 +52,7 @@ def test_write_read_csv(tmp_path):
     assert read_data.demag_factor == collection.demag_factor
     assert list(read_data.comments) == collection.comments
     assert read_data["the length"] == collection["the length"]
+    assert read_data["description"] == collection["description"]
 
     df_without_units = read_data.to_dataframe()
     assert list(df_without_units.columns) == [
@@ -60,6 +62,7 @@ def test_write_read_csv(tmp_path):
         "demag_factor",
         "comments",
         "the length",
+        "description",
     ]
 
     df_with_units = read_data.to_dataframe(include_units=True)
@@ -70,6 +73,7 @@ def test_write_read_csv(tmp_path):
         "demag_factor",
         "comments",
         "the length (m)",
+        "description (m)",
     ]
 
     df = pd.read_csv(tmp_path / "example.csv", header=9)

--- a/tests/test_entity_collection.py
+++ b/tests/test_entity_collection.py
@@ -35,8 +35,10 @@ def test_entity_name_clash():
     assert ec.to_dataframe == "missing"
     assert ec["to_dataframe"] == me.Ms()
 
-    with pytest.raises(KeyError):
-        ec["description"] = me.T()
+    # 'description' can be used as entity-like name if accessed via dict interface
+    ec["description"] = me.T()
+    assert isinstance(ec["description"], me.Entity)
+    assert ec.description == ""
 
 
 def test_entity_name_must_be_string():
@@ -109,7 +111,6 @@ def test_metadata():
         V=1,
     )
     reference = {
-        "description": "descr",
         "M": {"ontology_label": "Magnetization", "unit": "A / m", "description": ""},
         "Tc": {"ontology_label": "CurieTemperature", "unit": "K", "description": "low"},
         "T_q": {"unit": "K"},
@@ -163,13 +164,13 @@ def test_to_dataframe_unsupported():
 def test_from_dataframe():
     data = pd.DataFrame({"M": [1, 2], "T": [3, 4], "l_q": [5, 6], "x": [7, 8]})
     metadata = {
-        "description": "",
         "M": {"ontology_label": "Magnetization", "unit": "kA/m", "description": "abc"},
         "T": {"ontology_label": "ThermodynamicTemperature"},
         "l_q": {"unit": "m"},
         "x": {},
     }
-    collection = me.EntityCollection.from_dataframe(data, metadata)
+    collection = me.EntityCollection.from_dataframe(data, metadata, description="desc")
+    assert collection.description == "desc"
     assert me.M([1, 2], "kA/m") == collection.M
     assert collection.M.description == "abc"
     assert me.T([3, 4], "K") == collection.T
@@ -183,9 +184,19 @@ def test_dataframe_roundtrip():
     Tq = me.T([3, 4]).q
     V = [5, 6]
     col = me.EntityCollection("descr", M=M, Tq=Tq, V=V)
-    col_new = me.EntityCollection.from_dataframe(col.to_dataframe(), col.metadata())
+    col["name with spaces"] = [0, 0]
+    col["description"] = [1, 1]
+    col_new = me.EntityCollection.from_dataframe(
+        col.to_dataframe(), col.metadata(), col.description
+    )
     assert col_new.M == M
     assert all(col_new.Tq == Tq)
     assert all(col_new.V == V)
     assert col_new.description == "descr"
-    assert [name for name, _entity in col_new] == ["M", "Tq", "V"]
+    assert [name for name, _entity in col_new] == [
+        "M",
+        "Tq",
+        "V",
+        "name with spaces",
+        "description",
+    ]

--- a/tests/test_hdf5.py
+++ b/tests/test_hdf5.py
@@ -80,15 +80,17 @@ def test_entity_collection_to_hdf5_roundtrip():
             T=me.T([50, 100, 200]),
             Tc=me.Tc(600, "K"),
         )
+        col["description"] = me.Entity("Length", [0, 0, 0])
         col.to_hdf5(f, "/sample1/properties")
 
         col_read = me.from_hdf5(f["/sample1/properties"])
         assert isinstance(col_read, me.EntityCollection)
         assert col_read.description == col.description
-        assert [name for name, _entity in col_read] == ["Ms", "T", "Tc"]
+        assert [name for name, _entity in col_read] == ["Ms", "T", "Tc", "description"]
         assert col_read.Ms == col.Ms
         assert col_read.T == col.T
         assert col_read.Tc == col.Tc
+        assert col_read["description"] == col["description"]
 
 
 def test_entity_collection_to_hdf5_extra_features_do_not_affect_read():

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -28,6 +28,7 @@ def test_write_read_yaml(tmp_path):
         comments=["Some comment", "Some other comment", "A third comment"],
     )
     collection["the length"] = me.Entity("Length", [1, 2, 3])
+    collection["description"] = me.Entity("Length", [0, 0, 0])
     collection.to_yaml(tmp_path / "example.yaml")
 
     read_data = me.from_yaml(tmp_path / "example.yaml")
@@ -44,6 +45,7 @@ def test_write_read_yaml(tmp_path):
     assert read_data.demag_factor == collection.demag_factor
     assert list(read_data.comments) == collection.comments
     assert read_data["the length"] == collection["the length"]
+    assert read_data["description"] == collection["description"]
 
 
 def test_read_yaml_v1(tmp_path):


### PR DESCRIPTION
The docstring changes should clarify how `description` (and other special names) can be set/accessed.

closes #231 