### PR TITLE
implementation of .to feature

### DIFF
--- a/changes/236.added.md
+++ b/changes/236.added.md
@@ -1,1 +1,1 @@
-Added `Entity.to()` for ontology-compatible entity unit conversions, including ordinary metric-prefix rescalings and explicit dimension-constrained trivial conversions.
+Added `Entity.to()` for ontology-compatible entity unit conversions, including ordinary metric-prefix rescalings and explicit dimension-constrained conversions.

--- a/changes/236.added.md
+++ b/changes/236.added.md
@@ -1,0 +1,1 @@
+Added `Entity.to()` for ontology-compatible entity unit conversions, including ordinary metric-prefix rescalings and explicit dimension-constrained trivial conversions.

--- a/changes/236.added.md
+++ b/changes/236.added.md
@@ -1,1 +1,1 @@
-Added `Entity.to()` for ontology-compatible entity unit conversions, including ordinary metric-prefix rescalings and explicit dimension-constrained conversions.
+Added `Entity.to()` for ordinary ontology-compatible unit rescalings.

--- a/src/mammos_entity/_entity.py
+++ b/src/mammos_entity/_entity.py
@@ -80,7 +80,6 @@ def _is_metric_prefixed_symbol(unit, reference_unit) -> bool:
 class ConversionType(Enum):
     ORDINARY = "ordinary"  # category 1
     DIMENSION_CONSTRAINED_TRIVIAL = "dimension_constrained_trivial"  # category 3
-    RELATION_CHANGING = "relation_changing"  # category 4
 
     # Optional backwards-compatible alias.
     TRIVIAL = "dimension_constrained_trivial"
@@ -698,17 +697,11 @@ class Entity:
         do not guarantee relation preservation. The returned entity must still be
         ontology/unit-compatible.
 
-        Relation-changing conversions are not handled by Entity.to(), because they
-        require a system- or convention-level conversion.
+        System-level conversions that transform relation systems are outside the
+        scope of Entity.to().
         """
         conversion_type = _as_conversion_type(conversion_type)
         target_unit = u.Unit(unit)
-
-        if conversion_type is ConversionType.RELATION_CHANGING:
-            raise ValueError(
-                "Relation-changing conversions cannot be performed by Entity.to(). "
-                "They require a system or convention-level conversion."
-            )
 
         if conversion_type is ConversionType.ORDINARY:
             self._validate_ordinary_conversion(target_unit)

--- a/src/mammos_entity/_entity.py
+++ b/src/mammos_entity/_entity.py
@@ -79,23 +79,12 @@ def _is_metric_prefixed_symbol(unit, reference_unit) -> bool:
 
 class ConversionType(Enum):
     ORDINARY = "ordinary"  # category 1
-    DIMENSION_CONSTRAINED_TRIVIAL = "dimension_constrained_trivial"  # category 3
-
-    # Optional backwards-compatible alias.
-    TRIVIAL = "dimension_constrained_trivial"
+    DIMENSION_CONSTRAINED = "dimension_constrained"  # category 3
 
 
 def _as_conversion_type(value: ConversionType | str) -> ConversionType:
     if isinstance(value, ConversionType):
         return value
-    if value == "trivial":
-        return ConversionType.DIMENSION_CONSTRAINED_TRIVIAL
-    if value == "unconstrained_trivial":
-        raise ValueError(
-            "Unconstrained trivial conversions are not supported by Entity.to(). "
-            "Use conversion_type='dimension_constrained_trivial' for isolated "
-            "ontology-compatible conversions."
-        )
     return ConversionType(value)
 
 
@@ -640,7 +629,7 @@ class Entity:
                 f"{target_unit} for entity {self.ontology_label}. "
                 "Both source and target units must be pure rescalings of an "
                 "ontology unit. "
-                "Use conversion_type='dimension_constrained_trivial' for explicit "
+                "Use conversion_type='dimension_constrained' for explicit "
                 "isolated mappings."
             )
 
@@ -653,7 +642,7 @@ class Entity:
                 f"{target_unit} for entity {self.ontology_label}. "
                 "This conversion is affine or offset-based, not a pure linear "
                 "rescaling. "
-                "Use conversion_type='dimension_constrained_trivial' for isolated "
+                "Use conversion_type='dimension_constrained' for isolated "
                 "value conversions."
             )
 
@@ -663,15 +652,15 @@ class Entity:
                 f"{target_unit} for entity {self.ontology_label}. "
                 "This conversion is linear, but its scale factor is not a decimal "
                 "metric-prefix factor 10**k. "
-                "Use conversion_type='dimension_constrained_trivial' for explicit "
+                "Use conversion_type='dimension_constrained' for explicit "
                 "isolated mappings."
             )
 
-    def _validate_dimension_constrained_trivial_conversion(
+    def _validate_dimension_constrained_conversion(
         self,
         target_unit: mammos_units.UnitBase,
     ) -> None:
-        """Validate a dimension-constrained trivial conversion.
+        """Validate a dimension-constrained conversion.
 
         These are isolated entity conversions. They may use equivalencies allowed
         by the current unit system, but they do not guarantee relation preservation.
@@ -692,9 +681,9 @@ class Entity:
         restricted to pure rescalings of ontology-compatible units. They are intended
         for representation changes that do not alter the relation structure.
 
-        Dimension-constrained trivial conversions are isolated entity conversions.
-        They may use unit equivalencies allowed by the current unit system, but they
-        do not guarantee relation preservation. The returned entity must still be
+        Dimension-constrained conversions are isolated entity conversions. They may
+        use unit equivalencies allowed by the current unit system, but they do not
+        guarantee relation preservation. The returned entity must still be
         ontology/unit-compatible.
 
         System-level conversions that transform relation systems are outside the
@@ -706,8 +695,8 @@ class Entity:
         if conversion_type is ConversionType.ORDINARY:
             self._validate_ordinary_conversion(target_unit)
 
-        elif conversion_type is ConversionType.DIMENSION_CONSTRAINED_TRIVIAL:
-            self._validate_dimension_constrained_trivial_conversion(target_unit)
+        elif conversion_type is ConversionType.DIMENSION_CONSTRAINED:
+            self._validate_dimension_constrained_conversion(target_unit)
 
         else:
             raise ValueError(f"Unsupported conversion type: {conversion_type}")

--- a/src/mammos_entity/_entity.py
+++ b/src/mammos_entity/_entity.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 
 import os
 import re
+from enum import Enum
 from typing import TYPE_CHECKING
 
 import h5py
 import mammos_units as u
+import numpy as np
 
 import mammos_entity as me
 from mammos_entity._ontology import mammos_ontology, search_labels
@@ -25,9 +27,153 @@ if TYPE_CHECKING:
 
     import mammos_entity
 
-
 base_units = [u.T, u.J, u.m, u.A, u.radian, u.kg, u.s, u.K, u.mol, u.cd, u.V]
 mammos_equivalencies = u.temperature()
+
+
+_METRIC_PREFIXES = (
+    "Q",
+    "R",
+    "Y",
+    "Z",
+    "E",
+    "P",
+    "T",
+    "G",
+    "M",
+    "k",
+    "h",
+    "da",
+    "d",
+    "c",
+    "m",
+    "u",
+    "n",
+    "p",
+    "f",
+    "a",
+    "z",
+    "y",
+    "r",
+    "q",
+)
+
+
+def _is_metric_prefixed_symbol(unit, reference_unit) -> bool:
+    """Return True for simple metric-prefix spellings of a reference unit.
+
+    Examples:
+        mT -> T   True
+        kJ -> J   True
+        G  -> T   False
+        eV -> J   False
+    """
+    unit = u.Unit(unit)
+    reference_unit = u.Unit(reference_unit)
+
+    unit_str = str(unit).replace(" ", "")
+    ref_str = str(reference_unit).replace(" ", "")
+
+    return any(unit_str == f"{prefix}{ref_str}" for prefix in _METRIC_PREFIXES)
+
+
+class ConversionType(Enum):
+    ORDINARY = "ordinary"  # category 1
+    DIMENSION_CONSTRAINED_TRIVIAL = "dimension_constrained_trivial"  # category 3
+    RELATION_CHANGING = "relation_changing"  # category 4
+
+    # Optional backwards-compatible alias.
+    TRIVIAL = "dimension_constrained_trivial"
+
+
+def _as_conversion_type(value: ConversionType | str) -> ConversionType:
+    if isinstance(value, ConversionType):
+        return value
+    if value == "trivial":
+        return ConversionType.DIMENSION_CONSTRAINED_TRIVIAL
+    if value == "unconstrained_trivial":
+        raise ValueError(
+            "Unconstrained trivial conversions are not supported by Entity.to(). "
+            "Use conversion_type='dimension_constrained_trivial' for isolated "
+            "ontology-compatible conversions."
+        )
+    return ConversionType(value)
+
+
+def _deprefix_unit(unit: mammos_units.UnitBase) -> mammos_units.UnitBase:
+    """Remove metric prefixes from a unit.
+
+    Examples:
+        kA / m -> A / m
+        mA / cm -> A / m
+    """
+    unit = u.Unit(unit)
+
+    if hasattr(unit, "bases") and hasattr(unit, "powers"):
+        bases = []
+        for base in unit.bases:
+            if hasattr(base, "represents"):
+                if (
+                    hasattr(base.represents, "bases")
+                    and hasattr(base.represents, "powers")
+                    and len(base.represents.bases) == 1
+                    and base.represents.powers == [1]
+                    and (
+                        base == base.represents.bases[0]
+                        or _is_metric_prefixed_symbol(base, base.represents.bases[0])
+                    )
+                ):
+                    bases.append(base.represents.bases[0])
+                    continue
+                decomposed = base.represents.decompose()
+                if len(decomposed.bases) == 1 and decomposed.powers == [1]:
+                    bases.append(decomposed.bases[0])
+                else:
+                    bases.append(base)
+            else:
+                bases.append(base)
+
+        return u.CompositeUnit(1, bases, unit.powers)
+
+    return unit
+
+
+def _is_scaled_version_of(unit, reference_unit) -> bool:
+    """Return True if unit is a metric-prefix variant of reference_unit.
+
+    Examples:
+        A / m  -> kA / m  True
+        T      -> mT      True
+        A / m  -> Oe      False
+        T      -> G       False
+    """
+    unit = u.Unit(unit)
+    reference_unit = u.Unit(reference_unit)
+
+    if _deprefix_unit(unit) == _deprefix_unit(reference_unit):
+        return True
+
+    return _is_metric_prefixed_symbol(unit, reference_unit)
+
+
+def _has_decimal_scale(source_unit, target_unit) -> bool:
+    """Return True if converting source to target is multiplication by 10**k."""
+    source_unit = u.Unit(source_unit)
+    target_unit = u.Unit(target_unit)
+
+    with u.set_enabled_equivalencies(mammos_equivalencies):
+        factor = u.Quantity(1, source_unit).to(target_unit).value
+
+    factor = np.asarray(factor)
+    if factor.shape != () or not np.isfinite(factor):
+        return False
+
+    factor = float(factor)
+    if factor == 0:
+        return False
+
+    exponent = np.log10(abs(factor))
+    return np.allclose(exponent, round(exponent))
 
 
 def _convert_unit(
@@ -469,6 +615,115 @@ class Entity:
         """
         return re.sub(r"(?<!^)(?=[A-Z])", " ", f"{self.ontology_label}") + (
             f" ({self.unit})" if str(self.unit) else ""
+        )
+
+    def _validate_ordinary_conversion(
+        self,
+        target_unit: mammos_units.UnitBase,
+    ) -> None:
+        target_unit = u.Unit(target_unit)
+
+        if self.unit == target_unit:
+            return
+
+        ontology_units = _get_all_possible_units(self.ontology_label)
+
+        source_is_ordinary_unit = any(
+            _is_scaled_version_of(self.unit, ou) for ou in ontology_units
+        )
+        target_is_ordinary_unit = any(
+            _is_scaled_version_of(target_unit, ou) for ou in ontology_units
+        )
+
+        if not source_is_ordinary_unit or not target_is_ordinary_unit:
+            raise ValueError(
+                f"Cannot perform ordinary conversion from {self.unit} to "
+                f"{target_unit} for entity {self.ontology_label}. "
+                "Both source and target units must be pure rescalings of an "
+                "ontology unit. "
+                "Use conversion_type='dimension_constrained_trivial' for explicit "
+                "isolated mappings."
+            )
+
+        with u.set_enabled_equivalencies(mammos_equivalencies):
+            zero = u.Quantity(0, self.unit).to(target_unit).value
+
+        if not np.allclose(zero, 0):
+            raise ValueError(
+                f"Cannot perform ordinary conversion from {self.unit} to "
+                f"{target_unit} for entity {self.ontology_label}. "
+                "This conversion is affine or offset-based, not a pure linear "
+                "rescaling. "
+                "Use conversion_type='dimension_constrained_trivial' for isolated "
+                "value conversions."
+            )
+
+        if not _has_decimal_scale(self.unit, target_unit):
+            raise ValueError(
+                f"Cannot perform ordinary conversion from {self.unit} to "
+                f"{target_unit} for entity {self.ontology_label}. "
+                "This conversion is linear, but its scale factor is not a decimal "
+                "metric-prefix factor 10**k. "
+                "Use conversion_type='dimension_constrained_trivial' for explicit "
+                "isolated mappings."
+            )
+
+    def _validate_dimension_constrained_trivial_conversion(
+        self,
+        target_unit: mammos_units.UnitBase,
+    ) -> None:
+        """Validate a dimension-constrained trivial conversion.
+
+        These are isolated entity conversions. They may use equivalencies allowed
+        by the current unit system, but they do not guarantee relation preservation.
+
+        The Entity constructor still enforces ontology/unit compatibility.
+        """
+        return
+
+    def to(
+        self,
+        unit: str | mammos_units.UnitBase,
+        *,
+        conversion_type: ConversionType | str = ConversionType.ORDINARY,
+    ) -> mammos_entity.Entity:
+        """Return a copy of the entity converted to a different unit.
+
+        By default this performs an ordinary conversion. Ordinary conversions are
+        restricted to pure rescalings of ontology-compatible units. They are intended
+        for representation changes that do not alter the relation structure.
+
+        Dimension-constrained trivial conversions are isolated entity conversions.
+        They may use unit equivalencies allowed by the current unit system, but they
+        do not guarantee relation preservation. The returned entity must still be
+        ontology/unit-compatible.
+
+        Relation-changing conversions are not handled by Entity.to(), because they
+        require a system- or convention-level conversion.
+        """
+        conversion_type = _as_conversion_type(conversion_type)
+        target_unit = u.Unit(unit)
+
+        if conversion_type is ConversionType.RELATION_CHANGING:
+            raise ValueError(
+                "Relation-changing conversions cannot be performed by Entity.to(). "
+                "They require a system or convention-level conversion."
+            )
+
+        if conversion_type is ConversionType.ORDINARY:
+            self._validate_ordinary_conversion(target_unit)
+
+        elif conversion_type is ConversionType.DIMENSION_CONSTRAINED_TRIVIAL:
+            self._validate_dimension_constrained_trivial_conversion(target_unit)
+
+        else:
+            raise ValueError(f"Unsupported conversion type: {conversion_type}")
+
+        return self.__class__(
+            self.ontology_label,
+            self.quantity,
+            unit=target_unit,
+            description=self.description,
         )
 
     def __eq__(self, other: mammos_entity.Entity) -> bool:

--- a/src/mammos_entity/_entity.py
+++ b/src/mammos_entity/_entity.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import os
 import re
-from enum import Enum
 from typing import TYPE_CHECKING
 
 import h5py
@@ -67,25 +66,25 @@ def _is_metric_prefixed_symbol(unit, reference_unit) -> bool:
         kJ -> J   True
         G  -> T   False
         eV -> J   False
+        m s -> s  False
     """
     unit = u.Unit(unit)
     reference_unit = u.Unit(reference_unit)
+
+    if (
+        not hasattr(unit, "bases")
+        or not hasattr(reference_unit, "bases")
+        or len(unit.bases) != 1
+        or len(reference_unit.bases) != 1
+        or unit.powers != [1]
+        or reference_unit.powers != [1]
+    ):
+        return False
 
     unit_str = str(unit).replace(" ", "")
     ref_str = str(reference_unit).replace(" ", "")
 
     return any(unit_str == f"{prefix}{ref_str}" for prefix in _METRIC_PREFIXES)
-
-
-class ConversionType(Enum):
-    ORDINARY = "ordinary"  # category 1
-    DIMENSION_CONSTRAINED = "dimension_constrained"  # category 3
-
-
-def _as_conversion_type(value: ConversionType | str) -> ConversionType:
-    if isinstance(value, ConversionType):
-        return value
-    return ConversionType(value)
 
 
 def _deprefix_unit(unit: mammos_units.UnitBase) -> mammos_units.UnitBase:
@@ -628,9 +627,7 @@ class Entity:
                 f"Cannot perform ordinary conversion from {self.unit} to "
                 f"{target_unit} for entity {self.ontology_label}. "
                 "Both source and target units must be pure rescalings of an "
-                "ontology unit. "
-                "Use conversion_type='dimension_constrained' for explicit "
-                "isolated mappings."
+                "ontology unit."
             )
 
         with u.set_enabled_equivalencies(mammos_equivalencies):
@@ -641,9 +638,7 @@ class Entity:
                 f"Cannot perform ordinary conversion from {self.unit} to "
                 f"{target_unit} for entity {self.ontology_label}. "
                 "This conversion is affine or offset-based, not a pure linear "
-                "rescaling. "
-                "Use conversion_type='dimension_constrained' for isolated "
-                "value conversions."
+                "rescaling."
             )
 
         if not _has_decimal_scale(self.unit, target_unit):
@@ -651,55 +646,24 @@ class Entity:
                 f"Cannot perform ordinary conversion from {self.unit} to "
                 f"{target_unit} for entity {self.ontology_label}. "
                 "This conversion is linear, but its scale factor is not a decimal "
-                "metric-prefix factor 10**k. "
-                "Use conversion_type='dimension_constrained' for explicit "
-                "isolated mappings."
+                "metric-prefix factor 10**k."
             )
-
-    def _validate_dimension_constrained_conversion(
-        self,
-        target_unit: mammos_units.UnitBase,
-    ) -> None:
-        """Validate a dimension-constrained conversion.
-
-        These are isolated entity conversions. They may use equivalencies allowed
-        by the current unit system, but they do not guarantee relation preservation.
-
-        The Entity constructor still enforces ontology/unit compatibility.
-        """
-        return
 
     def to(
         self,
         unit: str | mammos_units.UnitBase,
-        *,
-        conversion_type: ConversionType | str = ConversionType.ORDINARY,
     ) -> mammos_entity.Entity:
         """Return a copy of the entity converted to a different unit.
 
-        By default this performs an ordinary conversion. Ordinary conversions are
-        restricted to pure rescalings of ontology-compatible units. They are intended
-        for representation changes that do not alter the relation structure.
-
-        Dimension-constrained conversions are isolated entity conversions. They may
-        use unit equivalencies allowed by the current unit system, but they do not
-        guarantee relation preservation. The returned entity must still be
-        ontology/unit-compatible.
+        This performs an ordinary conversion. Ordinary conversions are restricted
+        to pure rescalings of ontology-compatible units. They are intended for
+        representation changes that do not alter the relation structure.
 
         System-level conversions that transform relation systems are outside the
         scope of Entity.to().
         """
-        conversion_type = _as_conversion_type(conversion_type)
         target_unit = u.Unit(unit)
-
-        if conversion_type is ConversionType.ORDINARY:
-            self._validate_ordinary_conversion(target_unit)
-
-        elif conversion_type is ConversionType.DIMENSION_CONSTRAINED:
-            self._validate_dimension_constrained_conversion(target_unit)
-
-        else:
-            raise ValueError(f"Unsupported conversion type: {conversion_type}")
+        self._validate_ordinary_conversion(target_unit)
 
         return self.__class__(
             self.ontology_label,

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -347,6 +347,14 @@ def test_entity_to_ordinary_conversions():
     assert exchange.to("kJ/mm") == exchange
 
 
+def test_metric_prefix_detection_does_not_confuse_composite_units():
+    """Test that products such as m s are not parsed like prefixed units."""
+    assert me._entity._is_scaled_version_of("mK", "K")
+    assert not me._entity._is_scaled_version_of("m K", "K")
+    assert me._entity._is_scaled_version_of("ms", "s")
+    assert not me._entity._is_scaled_version_of("m s", "s")
+
+
 def test_entity_to_preserves_metadata():
     """Test that Entity.to preserves ontology label and description."""
     ms = me.Ms(100_000, "A/m", description="test description")
@@ -390,31 +398,25 @@ def test_entity_to_affine_temperature_is_not_ordinary_except_identity():
     assert temp_c.to("deg_C") == temp_c
 
 
-def test_entity_to_dimension_constrained_conversions():
-    """Test explicit dimension-constrained conversions."""
-    ms_oe = me.Ms(1, "A/m").to(
-        "Oe",
-        conversion_type="dimension_constrained",
-    )
-    assert ms_oe.unit == u.Oe
+def test_entity_to_rejects_non_ordinary_conversions():
+    """Test Entity.to only accepts ordinary conversions."""
+    with pytest.raises(ValueError, match="Both source and target units"):
+        me.Ms(1, "A/m").to("Oe")
 
-    b_g = me.B(1, "T").to(
-        "G",
-        conversion_type="dimension_constrained",
-    )
-    assert b_g.unit == u.G
+    with pytest.raises(ValueError, match="Both source and target units"):
+        me.B(1, "T").to("G")
 
-    temp_c = me.T(300, "K").to(
-        "deg_C",
-        conversion_type="dimension_constrained",
-    )
-    assert temp_c.unit == u.deg_C
+    with pytest.raises(ValueError, match="affine or offset-based"):
+        me.T(300, "K").to("deg_C")
+
+    with pytest.raises(ValueError, match="Both source and target units"):
+        me.Entity("Energy", 1, "J").to("eV")
 
 
-def test_entity_to_rejects_unsupported_conversion_type():
-    """Test unsupported conversion types are rejected."""
-    with pytest.raises(ValueError, match="'system' is not a valid ConversionType"):
-        me.B(1, "T").to("G", conversion_type="system")
+def test_entity_to_rejects_conversion_type_keyword():
+    """Test Entity.to does not expose alternative conversion modes."""
+    with pytest.raises(TypeError, match="unexpected keyword argument"):
+        me.B(1, "T").to("G", conversion_type="dimension_constrained")
 
 
 def test_entity_to_array_values():

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -334,6 +334,98 @@ def test_equality():
     assert e_1 == A()
 
 
+def test_entity_to_ordinary_conversions():
+    """Test ordinary Entity.to conversions for metric-prefix rescalings."""
+    ms = me.Ms(100_000, "A/m")
+    assert ms.to("kA/m") == ms
+    assert ms.to("mA/cm") == ms
+
+    b = me.B(1, "T")
+    assert b.to("mT") == b
+
+    exchange = me.A(1, "J/m")
+    assert exchange.to("kJ/mm") == exchange
+
+
+def test_entity_to_preserves_metadata():
+    """Test that Entity.to preserves ontology label and description."""
+    ms = me.Ms(100_000, "A/m", description="test description")
+    out = ms.to("kA/m")
+
+    assert out.ontology_label == ms.ontology_label
+    assert out.description == ms.description
+    assert out == ms
+
+
+def test_entity_to_special_units_are_not_ordinary_except_identity():
+    """Test special units are not ordinary conversions, except identity."""
+    with pytest.raises(ValueError, match="Both source and target units"):
+        me.Ms(1, "A/m").to("Oe")
+
+    with pytest.raises(ValueError, match="Both source and target units"):
+        me.Ms(1, "Oe").to("A/m")
+
+    ms_oe = me.Ms(1, "Oe")
+    assert ms_oe.to("Oe") == ms_oe
+
+    with pytest.raises(ValueError, match="Both source and target units"):
+        me.B(1, "T").to("G")
+
+    with pytest.raises(ValueError, match="Both source and target units"):
+        me.B(1, "G").to("T")
+
+    b_g = me.B(1, "G")
+    assert b_g.to("G") == b_g
+
+
+def test_entity_to_affine_temperature_is_not_ordinary_except_identity():
+    """Test affine temperature conversions are not ordinary, except identity."""
+    with pytest.raises(ValueError, match="affine or offset-based"):
+        me.T(300, "K").to("deg_C")
+
+    with pytest.raises(ValueError, match="affine or offset-based"):
+        me.T(26.85, "deg_C").to("K")
+
+    temp_c = me.T(26.85, "deg_C")
+    assert temp_c.to("deg_C") == temp_c
+
+
+def test_entity_to_dimension_constrained_trivial_conversions():
+    """Test explicit dimension-constrained trivial conversions."""
+    ms_oe = me.Ms(1, "A/m").to(
+        "Oe",
+        conversion_type="dimension_constrained_trivial",
+    )
+    assert ms_oe.unit == u.Oe
+
+    b_g = me.B(1, "T").to(
+        "G",
+        conversion_type="dimension_constrained_trivial",
+    )
+    assert b_g.unit == u.G
+
+    temp_c = me.T(300, "K").to(
+        "deg_C",
+        conversion_type="dimension_constrained_trivial",
+    )
+    assert temp_c.unit == u.deg_C
+
+
+def test_entity_to_rejects_unsupported_conversion_type():
+    """Test unsupported conversion types are rejected."""
+    with pytest.raises(ValueError, match="'system' is not a valid ConversionType"):
+        me.B(1, "T").to("G", conversion_type="system")
+
+
+def test_entity_to_array_values():
+    """Test Entity.to scales array values elementwise."""
+    b = me.B(np.array([1, 2, 3]), "T")
+    out = b.to("mT")
+
+    assert out.unit == u.mT
+    assert np.allclose(out.value, [1000, 2000, 3000])
+
+
 @pytest.mark.parametrize(
     "function, expected_label",
     (

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -390,23 +390,23 @@ def test_entity_to_affine_temperature_is_not_ordinary_except_identity():
     assert temp_c.to("deg_C") == temp_c
 
 
-def test_entity_to_dimension_constrained_trivial_conversions():
-    """Test explicit dimension-constrained trivial conversions."""
+def test_entity_to_dimension_constrained_conversions():
+    """Test explicit dimension-constrained conversions."""
     ms_oe = me.Ms(1, "A/m").to(
         "Oe",
-        conversion_type="dimension_constrained_trivial",
+        conversion_type="dimension_constrained",
     )
     assert ms_oe.unit == u.Oe
 
     b_g = me.B(1, "T").to(
         "G",
-        conversion_type="dimension_constrained_trivial",
+        conversion_type="dimension_constrained",
     )
     assert b_g.unit == u.G
 
     temp_c = me.T(300, "K").to(
         "deg_C",
-        conversion_type="dimension_constrained_trivial",
+        conversion_type="dimension_constrained",
     )
     assert temp_c.unit == u.deg_C
 


### PR DESCRIPTION
## Summary

This PR adds explicit conversion semantics to `Entity.to()`.

The default conversion type is now an ordinary conversion, restricted to pure decimal metric-prefix rescalings of ontology-compatible units. Isolated equivalency-style conversions such as `A/m <-> Oe`, `T <-> G`, `K <-> deg_C`, and `J <-> eV` can be requested explicitly as `dimension_constrained` conversions. Relation-changing conversions are rejected at the `Entity.to()` level because they require a system-level conversion.

## What changed

- Added `conversion_type` support to `Entity.to()`
- Added conversion categories:
  - `ordinary`
  - `dimension_constrained`
 
- Added stricter ordinary-conversion validation:
  - source and target units must both be pure rescalings of ontology-compatible units
  - affine/offset conversions are rejected
  - non-decimal or special-unit equivalencies are rejected as ordinary conversions
  - identity conversions remain ordinary, including special units


closes #219 