### PR TITLE
Re-introduce slicing of Entity objects

### DIFF
--- a/changes/243.added.md
+++ b/changes/243.added.md
@@ -1,0 +1,1 @@
+Re-introduce slicing of `Entity` objects. `Entity.__getitem__` delegates to the underlying Quantity and returns a new `Entity` preserving ontology label, unit, and description.

--- a/examples/entity.ipynb
+++ b/examples/entity.ipynb
@@ -1010,8 +1010,8 @@
    ],
    "source": [
     "# Create an entity with multiple values\n",
-    "Ms_array = me.Ms([500, 600, 700, 800], \"kA/m\", description=\"Temperature-dependent measurements\")\n",
-    "Ms_array"
+    "Ms_data = me.Ms([500, 600, 700, 800], \"kA/m\", description=\"Temperature-dependent measurements\")\n",
+    "Ms_data"
    ]
   },
   {
@@ -1043,7 +1043,7 @@
     }
    ],
    "source": [
-    "Ms_array[0]"
+    "Ms_data[0]"
    ]
   },
   {
@@ -1075,7 +1075,7 @@
     }
    ],
    "source": [
-    "Ms_array[1:3]"
+    "Ms_data[1:3]"
    ]
   },
   {
@@ -1107,7 +1107,7 @@
     }
    ],
    "source": [
-    "Ms_array[[True, False, True, False]]"
+    "Ms_data[[True, False, True, False]]"
    ]
   },
   {
@@ -1139,7 +1139,7 @@
     }
    ],
    "source": [
-    "Ms_array[[0, 2, 3]]"
+    "Ms_data[[0, 2, 3]]"
    ]
   },
   {
@@ -1167,7 +1167,7 @@
     }
    ],
    "source": [
-    "sliced = Ms_array[1:]\n",
+    "sliced = Ms_data[1:]\n",
     "print(f\"Ontology label: {sliced.ontology_label}\")\n",
     "print(f\"Unit: {sliced.unit}\")\n",
     "print(f\"Description: {sliced.description}\")"

--- a/examples/entity.ipynb
+++ b/examples/entity.ipynb
@@ -411,8 +411,8 @@
       "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
       "\u001b[31mValueError\u001b[39m                                Traceback (most recent call last)",
       "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[11]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m me.Ms(\u001b[32m1.2\u001b[39m, \u001b[33m\"T\"\u001b[39m)  \u001b[38;5;66;03m# Tesla not compatible with A/m\u001b[39;00m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/Projects/MaMMoS/mammos-entity/src/mammos_entity/_factory.py:311\u001b[39m, in \u001b[36mMs\u001b[39m\u001b[34m(value, unit, **kwargs)\u001b[39m\n\u001b[32m    292\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mMs\u001b[39m(\n\u001b[32m    293\u001b[39m     value: \u001b[38;5;28mint\u001b[39m | \u001b[38;5;28mfloat\u001b[39m | numpy.typing.ArrayLike = \u001b[32m0\u001b[39m,\n\u001b[32m    294\u001b[39m     unit: \u001b[38;5;28;01mNone\u001b[39;00m | \u001b[38;5;28mstr\u001b[39m = \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[32m    295\u001b[39m     **kwargs,\n\u001b[32m    296\u001b[39m ) -> mammos_entity.Entity:\n\u001b[32m    297\u001b[39m \u001b[38;5;250m    \u001b[39m\u001b[33;03m\"\"\"Create an Entity representing the spontaneous magnetization (Ms).\u001b[39;00m\n\u001b[32m    298\u001b[39m \n\u001b[32m    299\u001b[39m \u001b[33;03m    Args:\u001b[39;00m\n\u001b[32m   (...)\u001b[39m\u001b[32m    309\u001b[39m \n\u001b[32m    310\u001b[39m \u001b[33;03m    \"\"\"\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m311\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[30;43mEntity\u001b[39;49m\u001b[30;43m(\u001b[39;49m\u001b[30;43m\"\u001b[39;49m\u001b[30;43mSpontaneousMagnetization\u001b[39;49m\u001b[30;43m\"\u001b[39;49m\u001b[30;43m,\u001b[39;49m\u001b[30;43m \u001b[39;49m\u001b[30;43mvalue\u001b[39;49m\u001b[30;43m,\u001b[39;49m\u001b[30;43m \u001b[39;49m\u001b[30;43munit\u001b[39;49m\u001b[30;43m,\u001b[39;49m\u001b[30;43m \u001b[39;49m\u001b[30;43m*\u001b[39;49m\u001b[30;43m*\u001b[39;49m\u001b[30;43mkwargs\u001b[39;49m\u001b[30;43m)\u001b[39;49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/Projects/MaMMoS/mammos-entity/src/mammos_entity/_entity.py:340\u001b[39m, in \u001b[36mEntity.__init__\u001b[39m\u001b[34m(self, ontology_label, value, unit, description)\u001b[39m\n\u001b[32m    338\u001b[39m \u001b[38;5;28;01mwith\u001b[39;00m u.set_enabled_equivalencies(mammos_equivalencies):\n\u001b[32m    339\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28many\u001b[39m(unit.is_equivalent(ou) \u001b[38;5;28;01mfor\u001b[39;00m ou \u001b[38;5;129;01min\u001b[39;00m ontology_units):\n\u001b[32m--> \u001b[39m\u001b[32m340\u001b[39m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\n\u001b[32m    341\u001b[39m             \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mGiven unit: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00munit\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m incompatible with ontology. \u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    342\u001b[39m             \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mAllowed units for entity \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mlabel\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m are: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00montology_units\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m.\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    343\u001b[39m         )\n\u001b[32m    345\u001b[39m     \u001b[38;5;28mself\u001b[39m._quantity = u.Quantity(value=value, unit=unit)\n\u001b[32m    346\u001b[39m \u001b[38;5;28mself\u001b[39m._ontology_label = label\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/Projects/MaMMoS/mammos-entity/src/mammos_entity/_factory.py:309\u001b[39m, in \u001b[36mMs\u001b[39m\u001b[34m(value, unit, **kwargs)\u001b[39m\n\u001b[32m    290\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mMs\u001b[39m(\n\u001b[32m    291\u001b[39m     value: \u001b[38;5;28mint\u001b[39m | \u001b[38;5;28mfloat\u001b[39m | numpy.typing.ArrayLike = \u001b[32m0\u001b[39m,\n\u001b[32m    292\u001b[39m     unit: \u001b[38;5;28;01mNone\u001b[39;00m | \u001b[38;5;28mstr\u001b[39m = \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[32m    293\u001b[39m     **kwargs,\n\u001b[32m    294\u001b[39m ) -> mammos_entity.Entity:\n\u001b[32m    295\u001b[39m \u001b[38;5;250m    \u001b[39m\u001b[33;03m\"\"\"Create an Entity representing the spontaneous magnetization (Ms).\u001b[39;00m\n\u001b[32m    296\u001b[39m \n\u001b[32m    297\u001b[39m \u001b[33;03m    Args:\u001b[39;00m\n\u001b[32m   (...)\u001b[39m\u001b[32m    307\u001b[39m \n\u001b[32m    308\u001b[39m \u001b[33;03m    \"\"\"\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m309\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[30;43mEntity\u001b[39;49m\u001b[30;43m(\u001b[39;49m\u001b[30;43m\"\u001b[39;49m\u001b[30;43mSpontaneousMagnetization\u001b[39;49m\u001b[30;43m\"\u001b[39;49m\u001b[30;43m,\u001b[39;49m\u001b[30;43m \u001b[39;49m\u001b[30;43mvalue\u001b[39;49m\u001b[30;43m,\u001b[39;49m\u001b[30;43m \u001b[39;49m\u001b[30;43munit\u001b[39;49m\u001b[30;43m,\u001b[39;49m\u001b[30;43m \u001b[39;49m\u001b[30;43m*\u001b[39;49m\u001b[30;43m*\u001b[39;49m\u001b[30;43mkwargs\u001b[39;49m\u001b[30;43m)\u001b[39;49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/Projects/MaMMoS/mammos-entity/src/mammos_entity/_entity.py:324\u001b[39m, in \u001b[36mEntity.__init__\u001b[39m\u001b[34m(self, ontology_label, value, unit, description)\u001b[39m\n\u001b[32m    322\u001b[39m \u001b[38;5;28;01mwith\u001b[39;00m u.set_enabled_equivalencies(mammos_equivalencies):\n\u001b[32m    323\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28many\u001b[39m(unit.is_equivalent(ou) \u001b[38;5;28;01mfor\u001b[39;00m ou \u001b[38;5;129;01min\u001b[39;00m ontology_units):\n\u001b[32m--> \u001b[39m\u001b[32m324\u001b[39m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\n\u001b[32m    325\u001b[39m             \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mGiven unit: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00munit\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m incompatible with ontology. \u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    326\u001b[39m             \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mAllowed units for entity \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mlabel\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m are: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00montology_units\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m.\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    327\u001b[39m         )\n\u001b[32m    329\u001b[39m     \u001b[38;5;28mself\u001b[39m._quantity = u.Quantity(value=value, unit=unit)\n\u001b[32m    330\u001b[39m \u001b[38;5;28mself\u001b[39m._ontology_label = label\n",
       "\u001b[31mValueError\u001b[39m: Given unit: T incompatible with ontology. Allowed units for entity SpontaneousMagnetization are: [Unit(\"A / m\")]."
      ]
     }
@@ -559,9 +559,9 @@
     {
      "data": {
       "text/plain": [
-       "{'altLabel': [locstr('Ms', ''), locstr('SpontaneousMagnetisation', 'en-GB')],\n",
+       "{'elucidation': [locstr('The spontaneous magnetization, Ms, of a ferromagnet is the result\\nof alignment of the magnetic moments of individual atoms. Ms exists\\nwithin a domain of a ferromagnet.', 'en')],\n",
+       " 'altLabel': [locstr('Ms', ''), locstr('SpontaneousMagnetisation', 'en-GB')],\n",
        " 'prefLabel': [locstr('SpontaneousMagnetization', 'en-US')],\n",
-       " 'elucidation': [locstr('The spontaneous magnetization, Ms, of a ferromagnet is the result\\nof alignment of the magnetic moments of individual atoms. Ms exists\\nwithin a domain of a ferromagnet.', 'en')],\n",
        " 'wikipediaReference': [locstr('https://en.wikipedia.org/wiki/Spontaneous_magnetization', '')],\n",
        " 'IECEntry': [locstr('https://www.electropedia.org/iev/iev.nsf/display?openform&ievref=221-02-41', '')]}"
       ]
@@ -590,12 +590,12 @@
     {
      "data": {
       "text/plain": [
-       "{core.prefLabel,\n",
+       "{emmo.hasMeasurementUnit,\n",
        " magnetic-materials.wikipediaReference,\n",
-       " magnetic-materials.IECEntry,\n",
-       " emmo.hasMeasurementUnit,\n",
        " core.altLabel,\n",
-       " emmo.elucidation}"
+       " emmo.elucidation,\n",
+       " magnetic-materials.IECEntry,\n",
+       " core.prefLabel}"
       ]
      },
      "execution_count": 16,
@@ -1152,10 +1152,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "id": "b2c3d4e5-f6a7-8901-bcde-222222222222",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<samp>SpontaneousMagnetization(value=[800.&nbsp;700.&nbsp;600.&nbsp;500.],&nbsp;unit=kA&nbsp;/&nbsp;m,&nbsp;description='Temperature-dependent&nbsp;measurements')</samp>"
+      ],
+      "text/plain": [
+       "Entity(ontology_label='SpontaneousMagnetization', value=array([800., 700., 600., 500.]), unit='kA / m', description='Temperature-dependent measurements')"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "Ms_data[::-1]"
    ]
@@ -1170,10 +1184,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "id": "d4e5f6a7-b8c9-0123-defa-444444444444",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<samp>SpontaneousMagnetization(value=[800.&nbsp;700.&nbsp;600.&nbsp;500.],&nbsp;unit=kA&nbsp;/&nbsp;m,&nbsp;description='Temperature-dependent&nbsp;measurements')</samp>"
+      ],
+      "text/plain": [
+       "Entity(ontology_label='SpontaneousMagnetization', value=array([800., 700., 600., 500.]), unit='kA / m', description='Temperature-dependent measurements')"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "Ms_data[[3, 2, 1, 0]]"
    ]
@@ -1188,7 +1216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 35,
    "id": "e1f2a3b4-c5d6-7890-efab-901234567890",
    "metadata": {},
    "outputs": [
@@ -1221,7 +1249,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 36,
    "id": "2637b050-f912-4d0a-93ca-afaa5c70fd6b",
    "metadata": {},
    "outputs": [
@@ -1234,7 +1262,7 @@
        "Entity(ontology_label='ThermodynamicTemperature', value=array([1., 2., 3., 4.]), unit='K')"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1256,7 +1284,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 37,
    "id": "7edc4f8c-652f-46ad-9d30-a8a65b97c25c",
    "metadata": {},
    "outputs": [
@@ -1269,7 +1297,7 @@
        "Entity(ontology_label='ThermodynamicTemperature', value=array([1., 2., 3., 4., 5.]), unit='K')"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1311,7 +1339,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 38,
    "id": "991e1a21-c28d-4809-bb3f-19fb26f45996",
    "metadata": {},
    "outputs": [
@@ -1326,7 +1354,7 @@
        " 'SpontaneousMagnetization']"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1347,7 +1375,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 39,
    "id": "70029f4c-9711-4c92-ba91-c278fd536591",
    "metadata": {},
    "outputs": [
@@ -1357,7 +1385,7 @@
        "['Magnetization']"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1376,7 +1404,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 40,
    "id": "e30ea9fe-23bb-424e-ae8d-2cd6b789be71",
    "metadata": {
     "editable": true,
@@ -1406,7 +1434,7 @@
        " magnetic-materials.SwitchingFieldCoercivityExternal}"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1417,7 +1445,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 41,
    "id": "e5980076-cf24-43f8-92d4-98b5bfc93427",
    "metadata": {
     "editable": true,
@@ -1442,7 +1470,7 @@
        " magnetic-materials.SwitchingFieldCoercivityExternal}"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1467,7 +1495,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 42,
    "id": "2b8226c8-a13e-436e-90db-3e5f1665a48d",
    "metadata": {
     "editable": true,
@@ -1486,7 +1514,7 @@
        "Entity(ontology_label='AnisotropyField', value=np.float64(230.0), unit='A / m')"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1505,17 +1533,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 43,
    "id": "3cab1d14-ca1f-46dc-b5d5-3dac84df2595",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[emmo.Coercivity, emmo.Permeability, emmo.AmperePerMetre, emmo.AmpereTurnPerMetre, emmo.MagneticPolarisation, magnetic-materials.BinderCumulant, magnetic-materials.CoercivityHc, magnetic-materials.KneeField, magnetic-materials.ShapeAnisotropyConstant, magnetic-materials.MagneticHysteresisProperties, magnetic-materials.DemagnetizingField, magnetic-materials.KneeFieldExternal, magnetic-materials.MassMagnetizationUnit, magnetic-materials.UniaxialMagnetocrystallineAnisotropy, magnetic-materials.UniaxialMagneticAnisotropy, magnetic-materials.SpontaneousMagnetization, magnetic-materials.DemagnetizingFactor, magnetic-materials.ExternalSusceptibility, magnetic-materials.SaturationMagnetization, magnetic-materials.CoercivityHcExternal, magnetic-materials.UniaxialAnisotropyConstant, magnetic-materials.AnisotropyField, magnetic-materials.InternalSusceptibility]"
+       "[emmo.Permeability, emmo.Coercivity, emmo.AmperePerMetre, emmo.MagneticPolarisation, emmo.AmpereTurnPerMetre, magnetic-materials.MagneticHysteresisProperties, magnetic-materials.AnisotropyField, magnetic-materials.MassMagnetizationUnit, magnetic-materials.BinderCumulant, magnetic-materials.KneeField, magnetic-materials.DemagnetizingFactor, magnetic-materials.ShapeAnisotropyConstant, magnetic-materials.KneeFieldExternal, magnetic-materials.ExternalSusceptibility, magnetic-materials.CoercivityHcExternal, magnetic-materials.SaturationMagnetization, magnetic-materials.CoercivityHc, magnetic-materials.DemagnetizingField, magnetic-materials.UniaxialMagneticAnisotropy, magnetic-materials.UniaxialMagnetocrystallineAnisotropy, magnetic-materials.SpontaneousMagnetization, magnetic-materials.InternalSusceptibility, magnetic-materials.UniaxialAnisotropyConstant]"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/examples/entity.ipynb
+++ b/examples/entity.ipynb
@@ -1144,6 +1144,42 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a1b2c3d4-e5f6-7890-abcd-111111111111",
+   "metadata": {},
+   "source": [
+    "Slicing with `[::-1]` reverses the order of values:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2c3d4e5-f6a7-8901-bcde-222222222222",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Ms_data[::-1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3d4e5f6-a7b8-9012-cdef-333333333333",
+   "metadata": {},
+   "source": [
+    "Integer array indexing can reorder elements:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4e5f6a7-b8c9-0123-defa-444444444444",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Ms_data[[3, 2, 1, 0]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "d0e1f2a3-b4c5-6789-defa-890123456789",
    "metadata": {},
    "source": [

--- a/examples/entity.ipynb
+++ b/examples/entity.ipynb
@@ -983,6 +983,121 @@
    "id": "724e0df1-e8ed-49ff-9260-09d67b6519ef",
    "metadata": {},
    "source": [
+    "## Slicing Entities\n",
+    "\n",
+    "Entities support indexing and slicing operations, just like NumPy arrays. All indexing operations supported by NumPy are valid, including integers, slices, boolean arrays, and integer arrays."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create an entity with multiple values\n",
+    "Ms_array = me.Ms([500, 600, 700, 800], \"kA/m\", description=\"Temperature-dependent measurements\")\n",
+    "Ms_array"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+   "metadata": {},
+   "source": [
+    "Integer indexing returns a scalar entity:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Ms_array[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4e5f6a7-b8c9-0123-defa-234567890123",
+   "metadata": {},
+   "source": [
+    "Slice indexing returns an entity with a subset of values:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5f6a7b8-c9d0-1234-efab-345678901234",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Ms_array[1:3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6a7b8c9-d0e1-2345-fabc-456789012345",
+   "metadata": {},
+   "source": [
+    "Boolean indexing selects values where the mask is `True`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7b8c9d0-e1f2-3456-abcd-567890123456",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Ms_array[[True, False, True, False]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8c9d0e1-f2a3-4567-bcde-678901234567",
+   "metadata": {},
+   "source": [
+    "Integer array indexing selects values at given positions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c9d0e1f2-a3b4-5678-cdef-789012345678",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Ms_array[[0, 2, 3]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0e1f2a3-b4c5-6789-defa-890123456789",
+   "metadata": {},
+   "source": [
+    "The ontology label, unit, and description are preserved after slicing:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1f2a3b4-c5d6-7890-efab-901234567890",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sliced = Ms_array[1:]\n",
+    "print(f\"Ontology label: {sliced.ontology_label}\")\n",
+    "print(f\"Unit: {sliced.unit}\")\n",
+    "print(f\"Description: {sliced.description}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2a3b4c5-d6e7-8901-fabc-012345678901",
+   "metadata": {},
+   "source": [
     "## Extending an `Entity`\n",
     "\n",
     "Entities are immutable and adding additional values is not directly possible. Instead a new entity with the combined values has to be created. This can be conveniently done with the following function:"

--- a/examples/entity.ipynb
+++ b/examples/entity.ipynb
@@ -60,7 +60,7 @@
        "<samp>SpontaneousMagnetization(value=800000.0,&nbsp;unit=A&nbsp;/&nbsp;m)</samp>"
       ],
       "text/plain": [
-       "Entity(ontology_label='SpontaneousMagnetization', value=800000.0, unit='A / m')"
+       "Entity(ontology_label='SpontaneousMagnetization', value=np.float64(800000.0), unit='A / m')"
       ]
      },
      "execution_count": 2,
@@ -107,7 +107,7 @@
        "<samp>SpontaneousMagnetization(value=800000.0,&nbsp;unit=A&nbsp;/&nbsp;m)</samp>"
       ],
       "text/plain": [
-       "Entity(ontology_label='SpontaneousMagnetization', value=800000.0, unit='A / m')"
+       "Entity(ontology_label='SpontaneousMagnetization', value=np.float64(800000.0), unit='A / m')"
       ]
      },
      "execution_count": 3,
@@ -152,7 +152,7 @@
        "<samp>SpontaneousMagnetization(value=800.0,&nbsp;unit=kA&nbsp;/&nbsp;m)</samp>"
       ],
       "text/plain": [
-       "Entity(ontology_label='SpontaneousMagnetization', value=800.0, unit='kA / m')"
+       "Entity(ontology_label='SpontaneousMagnetization', value=np.float64(800.0), unit='kA / m')"
       ]
      },
      "execution_count": 4,
@@ -255,7 +255,7 @@
        "<samp>SpontaneousMagnetization(value=800.0,&nbsp;unit=kA&nbsp;/&nbsp;m)</samp>"
       ],
       "text/plain": [
-       "Entity(ontology_label='SpontaneousMagnetization', value=800.0, unit='kA / m')"
+       "Entity(ontology_label='SpontaneousMagnetization', value=np.float64(800.0), unit='kA / m')"
       ]
      },
      "execution_count": 7,
@@ -287,7 +287,7 @@
        "<samp>SpontaneousMagnetization(value=800.0,&nbsp;unit=kA&nbsp;/&nbsp;m,&nbsp;description='Evaluated&nbsp;using&nbsp;UppASD&nbsp;with&nbsp;70000&nbsp;Monte&nbsp;Carlo&nbsp;steps.')</samp>"
       ],
       "text/plain": [
-       "Entity(ontology_label='SpontaneousMagnetization', value=800.0, unit='kA / m', description='Evaluated using UppASD with 70000 Monte Carlo steps.')"
+       "Entity(ontology_label='SpontaneousMagnetization', value=np.float64(800.0), unit='kA / m', description='Evaluated using UppASD with 70000 Monte Carlo steps.')"
       ]
      },
      "execution_count": 8,
@@ -331,7 +331,7 @@
        "<samp>SpontaneousMagnetization(value=954929.6580315315,&nbsp;unit=A&nbsp;/&nbsp;m)</samp>"
       ],
       "text/plain": [
-       "Entity(ontology_label='SpontaneousMagnetization', value=954929.6580315315, unit='A / m')"
+       "Entity(ontology_label='SpontaneousMagnetization', value=np.float64(954929.6580315315), unit='A / m')"
       ]
      },
      "execution_count": 9,
@@ -410,9 +410,9 @@
      "traceback": [
       "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
       "\u001b[31mValueError\u001b[39m                                Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[11]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[43mme\u001b[49m\u001b[43m.\u001b[49m\u001b[43mMs\u001b[49m\u001b[43m(\u001b[49m\u001b[32;43m1.2\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mT\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m)\u001b[49m  \u001b[38;5;66;03m# Tesla not compatible with A/m\u001b[39;00m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/repos/mammos/mammos-devtools/packages/mammos-entity/src/mammos_entity/_factory.py:311\u001b[39m, in \u001b[36mMs\u001b[39m\u001b[34m(value, unit, **kwargs)\u001b[39m\n\u001b[32m    292\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mMs\u001b[39m(\n\u001b[32m    293\u001b[39m     value: \u001b[38;5;28mint\u001b[39m | \u001b[38;5;28mfloat\u001b[39m | numpy.typing.ArrayLike = \u001b[32m0\u001b[39m,\n\u001b[32m    294\u001b[39m     unit: \u001b[38;5;28;01mNone\u001b[39;00m | \u001b[38;5;28mstr\u001b[39m = \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[32m    295\u001b[39m     **kwargs,\n\u001b[32m    296\u001b[39m ) -> mammos_entity.Entity:\n\u001b[32m    297\u001b[39m \u001b[38;5;250m    \u001b[39m\u001b[33;03m\"\"\"Create an Entity representing the spontaneous magnetization (Ms).\u001b[39;00m\n\u001b[32m    298\u001b[39m \n\u001b[32m    299\u001b[39m \u001b[33;03m    Args:\u001b[39;00m\n\u001b[32m   (...)\u001b[39m\u001b[32m    309\u001b[39m \n\u001b[32m    310\u001b[39m \u001b[33;03m    \"\"\"\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m311\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mEntity\u001b[49m\u001b[43m(\u001b[49m\u001b[33;43m\"\u001b[39;49m\u001b[33;43mSpontaneousMagnetization\u001b[39;49m\u001b[33;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mvalue\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43munit\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n",
-      "\u001b[36mFile \u001b[39m\u001b[32m~/repos/mammos/mammos-devtools/packages/mammos-entity/src/mammos_entity/_entity.py:340\u001b[39m, in \u001b[36mEntity.__init__\u001b[39m\u001b[34m(self, ontology_label, value, unit, description)\u001b[39m\n\u001b[32m    338\u001b[39m \u001b[38;5;28;01mwith\u001b[39;00m u.set_enabled_equivalencies(mammos_equivalencies):\n\u001b[32m    339\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28many\u001b[39m(unit.is_equivalent(ou) \u001b[38;5;28;01mfor\u001b[39;00m ou \u001b[38;5;129;01min\u001b[39;00m ontology_units):\n\u001b[32m--> \u001b[39m\u001b[32m340\u001b[39m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\n\u001b[32m    341\u001b[39m             \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mGiven unit: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00munit\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m incompatible with ontology. \u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    342\u001b[39m             \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mAllowed units for entity \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mlabel\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m are: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00montology_units\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m.\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    343\u001b[39m         )\n\u001b[32m    345\u001b[39m     \u001b[38;5;28mself\u001b[39m._quantity = u.Quantity(value=value, unit=unit)\n\u001b[32m    346\u001b[39m \u001b[38;5;28mself\u001b[39m._ontology_label = label\n",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[11]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m me.Ms(\u001b[32m1.2\u001b[39m, \u001b[33m\"T\"\u001b[39m)  \u001b[38;5;66;03m# Tesla not compatible with A/m\u001b[39;00m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/Projects/MaMMoS/mammos-entity/src/mammos_entity/_factory.py:311\u001b[39m, in \u001b[36mMs\u001b[39m\u001b[34m(value, unit, **kwargs)\u001b[39m\n\u001b[32m    292\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34mMs\u001b[39m(\n\u001b[32m    293\u001b[39m     value: \u001b[38;5;28mint\u001b[39m | \u001b[38;5;28mfloat\u001b[39m | numpy.typing.ArrayLike = \u001b[32m0\u001b[39m,\n\u001b[32m    294\u001b[39m     unit: \u001b[38;5;28;01mNone\u001b[39;00m | \u001b[38;5;28mstr\u001b[39m = \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[32m    295\u001b[39m     **kwargs,\n\u001b[32m    296\u001b[39m ) -> mammos_entity.Entity:\n\u001b[32m    297\u001b[39m \u001b[38;5;250m    \u001b[39m\u001b[33;03m\"\"\"Create an Entity representing the spontaneous magnetization (Ms).\u001b[39;00m\n\u001b[32m    298\u001b[39m \n\u001b[32m    299\u001b[39m \u001b[33;03m    Args:\u001b[39;00m\n\u001b[32m   (...)\u001b[39m\u001b[32m    309\u001b[39m \n\u001b[32m    310\u001b[39m \u001b[33;03m    \"\"\"\u001b[39;00m\n\u001b[32m--> \u001b[39m\u001b[32m311\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[30;43mEntity\u001b[39;49m\u001b[30;43m(\u001b[39;49m\u001b[30;43m\"\u001b[39;49m\u001b[30;43mSpontaneousMagnetization\u001b[39;49m\u001b[30;43m\"\u001b[39;49m\u001b[30;43m,\u001b[39;49m\u001b[30;43m \u001b[39;49m\u001b[30;43mvalue\u001b[39;49m\u001b[30;43m,\u001b[39;49m\u001b[30;43m \u001b[39;49m\u001b[30;43munit\u001b[39;49m\u001b[30;43m,\u001b[39;49m\u001b[30;43m \u001b[39;49m\u001b[30;43m*\u001b[39;49m\u001b[30;43m*\u001b[39;49m\u001b[30;43mkwargs\u001b[39;49m\u001b[30;43m)\u001b[39;49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32m~/Projects/MaMMoS/mammos-entity/src/mammos_entity/_entity.py:340\u001b[39m, in \u001b[36mEntity.__init__\u001b[39m\u001b[34m(self, ontology_label, value, unit, description)\u001b[39m\n\u001b[32m    338\u001b[39m \u001b[38;5;28;01mwith\u001b[39;00m u.set_enabled_equivalencies(mammos_equivalencies):\n\u001b[32m    339\u001b[39m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28many\u001b[39m(unit.is_equivalent(ou) \u001b[38;5;28;01mfor\u001b[39;00m ou \u001b[38;5;129;01min\u001b[39;00m ontology_units):\n\u001b[32m--> \u001b[39m\u001b[32m340\u001b[39m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\n\u001b[32m    341\u001b[39m             \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mGiven unit: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00munit\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m incompatible with ontology. \u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    342\u001b[39m             \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[33mAllowed units for entity \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mlabel\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m are: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00montology_units\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m.\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m    343\u001b[39m         )\n\u001b[32m    345\u001b[39m     \u001b[38;5;28mself\u001b[39m._quantity = u.Quantity(value=value, unit=unit)\n\u001b[32m    346\u001b[39m \u001b[38;5;28mself\u001b[39m._ontology_label = label\n",
       "\u001b[31mValueError\u001b[39m: Given unit: T incompatible with ontology. Allowed units for entity SpontaneousMagnetization are: [Unit(\"A / m\")]."
      ]
     }
@@ -559,8 +559,8 @@
     {
      "data": {
       "text/plain": [
-       "{'prefLabel': [locstr('SpontaneousMagnetization', 'en-US')],\n",
-       " 'altLabel': [locstr('Ms', ''), locstr('SpontaneousMagnetisation', 'en-GB')],\n",
+       "{'altLabel': [locstr('Ms', ''), locstr('SpontaneousMagnetisation', 'en-GB')],\n",
+       " 'prefLabel': [locstr('SpontaneousMagnetization', 'en-US')],\n",
        " 'elucidation': [locstr('The spontaneous magnetization, Ms, of a ferromagnet is the result\\nof alignment of the magnetic moments of individual atoms. Ms exists\\nwithin a domain of a ferromagnet.', 'en')],\n",
        " 'wikipediaReference': [locstr('https://en.wikipedia.org/wiki/Spontaneous_magnetization', '')],\n",
        " 'IECEntry': [locstr('https://www.electropedia.org/iev/iev.nsf/display?openform&ievref=221-02-41', '')]}"
@@ -590,12 +590,12 @@
     {
      "data": {
       "text/plain": [
-       "{magnetic-materials.IECEntry,\n",
+       "{core.prefLabel,\n",
        " magnetic-materials.wikipediaReference,\n",
-       " emmo.elucidation,\n",
-       " core.prefLabel,\n",
+       " magnetic-materials.IECEntry,\n",
+       " emmo.hasMeasurementUnit,\n",
        " core.altLabel,\n",
-       " emmo.hasMeasurementUnit}"
+       " emmo.elucidation}"
       ]
      },
      "execution_count": 16,
@@ -746,7 +746,7 @@
     {
      "data": {
       "text/plain": [
-       "954929.6580315315"
+       "np.float64(954929.6580315315)"
       ]
      },
      "execution_count": 20,
@@ -990,10 +990,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<samp>SpontaneousMagnetization(value=[500.&nbsp;600.&nbsp;700.&nbsp;800.],&nbsp;unit=kA&nbsp;/&nbsp;m,&nbsp;description='Temperature-dependent&nbsp;measurements')</samp>"
+      ],
+      "text/plain": [
+       "Entity(ontology_label='SpontaneousMagnetization', value=array([500., 600., 700., 800.]), unit='kA / m', description='Temperature-dependent measurements')"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Create an entity with multiple values\n",
     "Ms_array = me.Ms([500, 600, 700, 800], \"kA/m\", description=\"Temperature-dependent measurements\")\n",
@@ -1010,10 +1024,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "id": "c3d4e5f6-a7b8-9012-cdef-123456789012",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<samp>SpontaneousMagnetization(value=500.0,&nbsp;unit=kA&nbsp;/&nbsp;m,&nbsp;description='Temperature-dependent&nbsp;measurements')</samp>"
+      ],
+      "text/plain": [
+       "Entity(ontology_label='SpontaneousMagnetization', value=np.float64(500.0), unit='kA / m', description='Temperature-dependent measurements')"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "Ms_array[0]"
    ]
@@ -1028,10 +1056,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "id": "e5f6a7b8-c9d0-1234-efab-345678901234",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<samp>SpontaneousMagnetization(value=[600.&nbsp;700.],&nbsp;unit=kA&nbsp;/&nbsp;m,&nbsp;description='Temperature-dependent&nbsp;measurements')</samp>"
+      ],
+      "text/plain": [
+       "Entity(ontology_label='SpontaneousMagnetization', value=array([600., 700.]), unit='kA / m', description='Temperature-dependent measurements')"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "Ms_array[1:3]"
    ]
@@ -1046,10 +1088,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "id": "a7b8c9d0-e1f2-3456-abcd-567890123456",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<samp>SpontaneousMagnetization(value=[500.&nbsp;700.],&nbsp;unit=kA&nbsp;/&nbsp;m,&nbsp;description='Temperature-dependent&nbsp;measurements')</samp>"
+      ],
+      "text/plain": [
+       "Entity(ontology_label='SpontaneousMagnetization', value=array([500., 700.]), unit='kA / m', description='Temperature-dependent measurements')"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "Ms_array[[True, False, True, False]]"
    ]
@@ -1064,10 +1120,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "id": "c9d0e1f2-a3b4-5678-cdef-789012345678",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<samp>SpontaneousMagnetization(value=[500.&nbsp;700.&nbsp;800.],&nbsp;unit=kA&nbsp;/&nbsp;m,&nbsp;description='Temperature-dependent&nbsp;measurements')</samp>"
+      ],
+      "text/plain": [
+       "Entity(ontology_label='SpontaneousMagnetization', value=array([500., 700., 800.]), unit='kA / m', description='Temperature-dependent measurements')"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "Ms_array[[0, 2, 3]]"
    ]
@@ -1082,10 +1152,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 33,
    "id": "e1f2a3b4-c5d6-7890-efab-901234567890",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ontology label: SpontaneousMagnetization\n",
+      "Unit: kA / m\n",
+      "Description: Temperature-dependent measurements\n"
+     ]
+    }
+   ],
    "source": [
     "sliced = Ms_array[1:]\n",
     "print(f\"Ontology label: {sliced.ontology_label}\")\n",
@@ -1105,7 +1185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 34,
    "id": "2637b050-f912-4d0a-93ca-afaa5c70fd6b",
    "metadata": {},
    "outputs": [
@@ -1118,7 +1198,7 @@
        "Entity(ontology_label='ThermodynamicTemperature', value=array([1., 2., 3., 4.]), unit='K')"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1140,7 +1220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 35,
    "id": "7edc4f8c-652f-46ad-9d30-a8a65b97c25c",
    "metadata": {},
    "outputs": [
@@ -1153,7 +1233,7 @@
        "Entity(ontology_label='ThermodynamicTemperature', value=array([1., 2., 3., 4., 5.]), unit='K')"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1195,7 +1275,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 36,
    "id": "991e1a21-c28d-4809-bb3f-19fb26f45996",
    "metadata": {},
    "outputs": [
@@ -1210,7 +1290,7 @@
        " 'SpontaneousMagnetization']"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1231,7 +1311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 37,
    "id": "70029f4c-9711-4c92-ba91-c278fd536591",
    "metadata": {},
    "outputs": [
@@ -1241,7 +1321,7 @@
        "['Magnetization']"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1260,7 +1340,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 38,
    "id": "e30ea9fe-23bb-424e-ae8d-2cd6b789be71",
    "metadata": {
     "editable": true,
@@ -1290,7 +1370,7 @@
        " magnetic-materials.SwitchingFieldCoercivityExternal}"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1301,7 +1381,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 39,
    "id": "e5980076-cf24-43f8-92d4-98b5bfc93427",
    "metadata": {
     "editable": true,
@@ -1326,7 +1406,7 @@
        " magnetic-materials.SwitchingFieldCoercivityExternal}"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1351,7 +1431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 40,
    "id": "2b8226c8-a13e-436e-90db-3e5f1665a48d",
    "metadata": {
     "editable": true,
@@ -1367,10 +1447,10 @@
        "<samp>AnisotropyField(value=230.0,&nbsp;unit=A&nbsp;/&nbsp;m)</samp>"
       ],
       "text/plain": [
-       "Entity(ontology_label='AnisotropyField', value=230.0, unit='A / m')"
+       "Entity(ontology_label='AnisotropyField', value=np.float64(230.0), unit='A / m')"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1389,17 +1469,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 41,
    "id": "3cab1d14-ca1f-46dc-b5d5-3dac84df2595",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[emmo.AmperePerMetre, emmo.MagneticPolarisation, emmo.Permeability, emmo.Coercivity, emmo.AmpereTurnPerMetre, magnetic-materials.MagneticHysteresisProperties, magnetic-materials.KneeField, magnetic-materials.UniaxialMagnetocrystallineAnisotropy, magnetic-materials.UniaxialMagneticAnisotropy, magnetic-materials.KneeFieldExternal, magnetic-materials.MassMagnetizationUnit, magnetic-materials.DemagnetizingFactor, magnetic-materials.SpontaneousMagnetization, magnetic-materials.UniaxialAnisotropyConstant, magnetic-materials.CoercivityHc, magnetic-materials.DemagnetizingField, magnetic-materials.AnisotropyField, magnetic-materials.InternalSusceptibility, magnetic-materials.ExternalSusceptibility, magnetic-materials.SaturationMagnetization, magnetic-materials.CoercivityHcExternal, magnetic-materials.ShapeAnisotropyConstant]"
+       "[emmo.Coercivity, emmo.Permeability, emmo.AmperePerMetre, emmo.AmpereTurnPerMetre, emmo.MagneticPolarisation, magnetic-materials.BinderCumulant, magnetic-materials.CoercivityHc, magnetic-materials.KneeField, magnetic-materials.ShapeAnisotropyConstant, magnetic-materials.MagneticHysteresisProperties, magnetic-materials.DemagnetizingField, magnetic-materials.KneeFieldExternal, magnetic-materials.MassMagnetizationUnit, magnetic-materials.UniaxialMagnetocrystallineAnisotropy, magnetic-materials.UniaxialMagneticAnisotropy, magnetic-materials.SpontaneousMagnetization, magnetic-materials.DemagnetizingFactor, magnetic-materials.ExternalSusceptibility, magnetic-materials.SaturationMagnetization, magnetic-materials.CoercivityHcExternal, magnetic-materials.UniaxialAnisotropyConstant, magnetic-materials.AnisotropyField, magnetic-materials.InternalSusceptibility]"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/src/mammos_entity/_entity.py
+++ b/src/mammos_entity/_entity.py
@@ -480,9 +480,7 @@ class Entity:
 
         """  # noqa: E501
         sliced_quantity = self.quantity[key]
-        return self.__class__(
-            self.ontology_label, sliced_quantity, description=self.description
-        )
+        return self.__class__(self.ontology_label, sliced_quantity, description=self.description)
 
     @property
     def axis_label(self) -> str:

--- a/src/mammos_entity/_entity.py
+++ b/src/mammos_entity/_entity.py
@@ -435,7 +435,10 @@ class Entity:
         """Unit of the entity data."""
         return self.quantity.unit
 
-    def __getitem__(self, key):
+    def __getitem__(
+        self,
+        key: int | slice | list[int] | list[bool] | numpy.typing.ArrayLike,
+    ) -> Entity:
         """Index or slice the entity's values.
 
         Returns a new :py:class:`~mammos_entity.Entity` with the same ontology label,

--- a/src/mammos_entity/_entity.py
+++ b/src/mammos_entity/_entity.py
@@ -483,9 +483,9 @@ class Entity:
             Unit("kA / m")
 
         """  # noqa: E501
-        sliced_quantity = self._quantity[key]
+        sliced_quantity = self.quantity[key]
         return self.__class__(
-            self._ontology_label, sliced_quantity, description=self._description
+            self.ontology_label, sliced_quantity, description=self.description
         )
 
     @property

--- a/src/mammos_entity/_entity.py
+++ b/src/mammos_entity/_entity.py
@@ -435,6 +435,59 @@ class Entity:
         """Unit of the entity data."""
         return self.quantity.unit
 
+    def __getitem__(self, key):
+        """Index or slice the entity's values.
+
+        Returns a new :py:class:`Entity` with the same ontology label, unit, and
+        description, but with a subset of the values.
+
+        All indexing and slicing operations supported by NumPy are valid, including
+        integers, slices, ellipsis, boolean arrays, and integer arrays.
+
+        Args:
+            key: Index or slice to apply to the entity's values.
+
+        Returns:
+            A new :py:class:`Entity` with the same ontology label, unit and
+            description, containing the selected values.
+
+        Raises:
+            IndexError: If the entity has a scalar value and an index other than
+                ``()`` is used.
+
+        Examples:
+            >>> import mammos_entity as me
+            >>> Ms = me.Ms([500, 600, 700], "kA/m")
+
+            Integer indexing returns a scalar entity:
+
+            >>> Ms[0]
+            Entity(ontology_label='SpontaneousMagnetization', value=np.float64(500.0), unit='kA / m')
+
+            Slice indexing returns an entity with a subset of the values:
+
+            >>> Ms[1:3]
+            Entity(ontology_label='SpontaneousMagnetization', value=array([600., 700.]), unit='kA / m')
+
+            Boolean indexing selects values where the mask is ``True``:
+
+            >>> Ms[[True, False, True]]
+            Entity(ontology_label='SpontaneousMagnetization', value=array([500., 700.]), unit='kA / m')
+
+            The ontology label, unit, and description are preserved:
+
+            >>> sliced = Ms[1:]
+            >>> sliced.ontology_label
+            'SpontaneousMagnetization'
+            >>> sliced.unit
+            Unit("kA / m")
+
+        """  # noqa: E501
+        sliced_quantity = self._quantity[key]
+        return self.__class__(
+            self._ontology_label, sliced_quantity, description=self._description
+        )
+
     @property
     def axis_label(self) -> str:
         """Return an ontology-based axis label for the plots.

--- a/src/mammos_entity/_entity.py
+++ b/src/mammos_entity/_entity.py
@@ -438,8 +438,8 @@ class Entity:
     def __getitem__(self, key):
         """Index or slice the entity's values.
 
-        Returns a new :py:class:`Entity` with the same ontology label, unit, and
-        description, but with a subset of the values.
+        Returns a new :py:class:`~mammos_entity.Entity` with the same ontology label,
+        unit, and description, but with a subset of the values.
 
         All indexing and slicing operations supported by NumPy are valid, including
         integers, slices, ellipsis, boolean arrays, and integer arrays.
@@ -448,12 +448,8 @@ class Entity:
             key: Index or slice to apply to the entity's values.
 
         Returns:
-            A new :py:class:`Entity` with the same ontology label, unit and
-            description, containing the selected values.
-
-        Raises:
-            IndexError: If the entity has a scalar value and an index other than
-                ``()`` is used.
+            A new :py:class:`~mammos_entity.Entity` with the same ontology label,
+            unit and description, containing the selected values.
 
         Examples:
             >>> import mammos_entity as me

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -451,3 +451,95 @@ def test_from_compatible_wrong_kwarg():
             temperature=5,
             tc=5,
         )
+
+
+def test_getitem_int():
+    """Entity integer indexing returns scalar entity with label/unit preserved."""
+    ms = me.Ms([500, 600, 700], "kA/m", description="measured at 0 K")
+    result = ms[0]
+    assert result.ontology_label == "SpontaneousMagnetization"
+    assert result.unit == u.kA / u.m
+    assert result.description == "measured at 0 K"
+    assert math.isclose(result.value, 500.0)
+
+
+def test_getitem_slice():
+    """Entity slice indexing returns entity with subset of values."""
+    ms = me.Ms([500, 600, 700], "kA/m")
+    result = ms[1:3]
+    assert np.allclose(result.value, [600, 700])
+
+
+def test_getitem_step():
+    """Entity slice with step returns every Nth value."""
+    ms = me.Ms([500, 600, 700, 800], "kA/m")
+    result = ms[::2]
+    assert np.allclose(result.value, [500, 700])
+
+
+def test_getitem_negative():
+    """Negative integer indexing returns last element."""
+    ms = me.Ms([500, 600, 700], "kA/m")
+    result = ms[-1]
+    assert math.isclose(result.value, 700.0)
+
+
+def test_getitem_bool_array():
+    """Boolean array indexing selects values where mask is True."""
+    ms = me.Ms([500, 600, 700, 800], "kA/m")
+    result = ms[[True, False, True, False]]
+    assert np.allclose(result.value, [500, 700])
+
+
+def test_getitem_int_array():
+    """Integer array indexing selects values at given positions."""
+    ms = me.Ms([500, 600, 700, 800], "kA/m")
+    result = ms[[0, 2, 3]]
+    assert np.allclose(result.value, [500, 700, 800])
+
+
+def test_getitem_multidim():
+    """Multi-dimensional slicing works for 2D entity values."""
+    val = [[1, 2, 3], [4, 5, 6]]
+    ms = me.Ms(val, "A/m")
+    row = ms[0]
+    assert np.allclose(row.value, [1, 2, 3])
+    col = ms[:, 0]
+    assert np.allclose(col.value, [1, 4])
+
+
+def test_getitem_preserves_ontology_label():
+    """Slicing preserves ontology label."""
+    ms = me.Ms([500, 600, 700], "kA/m")
+    assert ms[0].ontology_label == "SpontaneousMagnetization"
+    assert ms[1:3].ontology_label == "SpontaneousMagnetization"
+    assert ms[[True, False, True]].ontology_label == "SpontaneousMagnetization"
+    assert ms[[0, 2]].ontology_label == "SpontaneousMagnetization"
+
+
+def test_getitem_preserves_unit():
+    """Slicing preserves unit."""
+    ms = me.Ms([500, 600, 700], "kA/m")
+    assert ms[0].unit == u.kA / u.m
+    assert ms[1:3].unit == u.kA / u.m
+
+
+def test_getitem_preserves_description():
+    """Slicing preserves description."""
+    ms = me.Ms([500, 600, 700], "kA/m", description="measured at 0 K")
+    assert ms[0].description == "measured at 0 K"
+    assert ms[1:3].description == "measured at 0 K"
+
+
+def test_getitem_scalar_entity_raises():
+    """Indexing a scalar entity raises TypeError."""
+    ms = me.Ms(500, "kA/m")
+    with pytest.raises(TypeError, match="scalar value does not support indexing"):
+        ms[0]
+
+
+def test_getitem_out_of_range():
+    """Index out of range raises IndexError."""
+    ms = me.Ms([500, 600, 700], "kA/m")
+    with pytest.raises(IndexError):
+        ms[999]

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -460,42 +460,42 @@ def test_getitem_int():
     assert result.ontology_label == "SpontaneousMagnetization"
     assert result.unit == u.kA / u.m
     assert result.description == "measured at 0 K"
-    assert math.isclose(result.value, 500.0)
+    assert result.value == 500.0
 
 
 def test_getitem_slice():
     """Entity slice indexing returns entity with subset of values."""
     ms = me.Ms([500, 600, 700], "kA/m")
     result = ms[1:3]
-    assert np.allclose(result.value, [600, 700])
+    assert np.array_equal(result.value, [600, 700])
 
 
 def test_getitem_step():
     """Entity slice with step returns every Nth value."""
     ms = me.Ms([500, 600, 700, 800], "kA/m")
     result = ms[::2]
-    assert np.allclose(result.value, [500, 700])
+    assert np.array_equal(result.value, [500, 700])
 
 
 def test_getitem_negative():
     """Negative integer indexing returns last element."""
     ms = me.Ms([500, 600, 700], "kA/m")
     result = ms[-1]
-    assert math.isclose(result.value, 700.0)
+    assert result.value == 700.0
 
 
 def test_getitem_bool_array():
     """Boolean array indexing selects values where mask is True."""
     ms = me.Ms([500, 600, 700, 800], "kA/m")
     result = ms[[True, False, True, False]]
-    assert np.allclose(result.value, [500, 700])
+    assert np.array_equal(result.value, [500, 700])
 
 
 def test_getitem_int_array():
     """Integer array indexing selects values at given positions."""
     ms = me.Ms([500, 600, 700, 800], "kA/m")
     result = ms[[0, 2, 3]]
-    assert np.allclose(result.value, [500, 700, 800])
+    assert np.array_equal(result.value, [500, 700, 800])
 
 
 def test_getitem_multidim():
@@ -503,9 +503,9 @@ def test_getitem_multidim():
     val = [[1, 2, 3], [4, 5, 6]]
     ms = me.Ms(val, "A/m")
     row = ms[0]
-    assert np.allclose(row.value, [1, 2, 3])
+    assert np.array_equal(row.value, [1, 2, 3])
     col = ms[:, 0]
-    assert np.allclose(col.value, [1, 4])
+    assert np.array_equal(col.value, [1, 4])
 
 
 def test_getitem_preserves_ontology_label():


### PR DESCRIPTION
Adds `Entity.__getitem__` so that `entity[key]` returns a new `Entity` preserving ontology label, unit, and description.

Closes #220