### PR TITLE
Update references to the ontology

### DIFF
--- a/LICENSE_ONTOLOGY
+++ b/LICENSE_ONTOLOGY
@@ -33,7 +33,7 @@ exhaustive, and do not form part of our licenses.
      material not subject to the license. This includes other CC-
      licensed material, or material used under an exception or
      limitation to copyright. More considerations for licensors:
-	wiki.creativecommons.org/Considerations_for_licensors
+     wiki.creativecommons.org/Considerations_for_licensors
 
      Considerations for the public: By using one of our public
      licenses, a licensor grants the public permission to use the
@@ -48,9 +48,9 @@ exhaustive, and do not form part of our licenses.
      rights in the material. A licensor may make special requests,
      such as asking that all changes be marked or described.
      Although not required by our licenses, you are encouraged to
-     respect those requests where reasonable. More_considerations
+     respect those requests where reasonable. More considerations
      for the public:
-	wiki.creativecommons.org/Considerations_for_licensees
+     wiki.creativecommons.org/Considerations_for_licensees
 
 =======================================================================
 
@@ -375,21 +375,21 @@ Section 8 -- Interpretation.
 
 =======================================================================
 
-Creative Commons is not a party to its public
-licenses. Notwithstanding, Creative Commons may elect to apply one of
-its public licenses to material it publishes and in those instances
-will be considered the “Licensor.” The text of the Creative Commons
-public licenses is dedicated to the public domain under the CC0 Public
-Domain Dedication. Except for the limited purpose of indicating that
-material is shared under a Creative Commons public license or as
-otherwise permitted by the Creative Commons policies published at
+Creative Commons is not a party to its public licenses.
+Notwithstanding, Creative Commons may elect to apply one of its public
+licenses to material it publishes and in those instances will be
+considered the “Licensor.” The text of the Creative Commons public
+licenses is dedicated to the public domain under the CC0 Public Domain
+Dedication. Except for the limited purpose of indicating that material
+is shared under a Creative Commons public license or as otherwise
+permitted by the Creative Commons policies published at
 creativecommons.org/policies, Creative Commons does not authorize the
 use of the trademark "Creative Commons" or any other trademark or logo
 of Creative Commons without its prior written consent including,
 without limitation, in connection with any unauthorized modifications
 to any of its public licenses or any other arrangements,
 understandings, or agreements concerning use of licensed material. For
-the avoidance of doubt, this paragraph does not form part of the
-public licenses.
+the avoidance of doubt, this paragraph does not form part of the public
+licenses.
 
 Creative Commons may be contacted at creativecommons.org.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mammos-entity
 
-`mammos-entity` provides entities. An **entity** is a quantity, which in addition links the entity to its definition in the [ontology](https://mammos-project.github.io/MagneticMaterialsOntology/doc/magnetic_material_mammos.html). A **quantity** is an object that carries a value and units.
+`mammos-entity` provides entities. An **entity** is a quantity, which in addition links the entity to its definition in the [MagMO ontology](https://emmo-repo.github.io/domain-magnetic-materials/). A **quantity** is an object that carries a value and units.
 
 | Description   | Badge                                                                                                                                                                                                                                                                                                      |
 |---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -39,9 +39,8 @@ The code is licensed under MIT.
 
 The ontology files in src/mammos_entity/ontology are licensed under CC-BY-4.0
 (LICENSE_ONTOLOGY). `emmo.ttl` is taken from
-[EMMO](https://github.com/emmo-repo/EMMO), `magnetic_material_mammos.ttl` is
-taken from [MaMMoS
-MagneticMaterialsOntology](https://github.com/MaMMoS-project/MagneticMaterialsOntology/tree/main).
+[EMMO](https://github.com/emmo-repo/EMMO), `magnetic-materials.ttl` is
+taken from [emmo-repo/domain-magnetic-materials](https://github.com/emmo-repo/domain-magnetic-materials).
 No modifications have been made to the ontology files.
 
 ## How to cite


### PR DESCRIPTION
Closes #244 

- Update links to new ontology repo https://github.com/emmo-repo/domain-magnetic-materials
- Update `LICENSE_ONTOLOGY` with https://github.com/emmo-repo/domain-magnetic-materials/blob/main/LICENSE.