### PR TITLE
Tab-completion for dict-like access of elements of an EntityCollection

### DIFF
--- a/changes/253.added.md
+++ b/changes/253.added.md
@@ -1,0 +1,1 @@
+Tab-completion for dict-like access of elements in an EntityCollection in ipython/Jupyter notebooks.

--- a/src/mammos_entity/_entity_collection.py
+++ b/src/mammos_entity/_entity_collection.py
@@ -234,6 +234,10 @@ class EntityCollection:
         else:
             raise ValueError(f"Description must be a string. Received value: {value} of type: {type(value)}.")
 
+    def _ipython_key_completions_(self) -> list[str]:
+        """Tab completion for dict-like access of entities in the collection."""
+        return list(self._entities.keys())
+
     def __repr__(self) -> str:
         """Show container elements."""
         args = f"description={self.description!r},\n"

--- a/tests/test_entity_collection.py
+++ b/tests/test_entity_collection.py
@@ -196,3 +196,14 @@ def test_dataframe_roundtrip():
         "name with spaces",
         "description",
     ]
+
+
+def test_ipython_key_completions_():
+    col = me.EntityCollection()
+    assert col._ipython_key_completions_() == []
+
+    col = me.EntityCollection(a=1, b=2)
+    assert col._ipython_key_completions_() == ["a", "b"]
+
+    col["another key"] = 3
+    assert col._ipython_key_completions_() == ["a", "b", "another key"]


### PR DESCRIPTION
When browsing a collection in a notebook/ipython tab-completion is available for the entity keys:

```ipython
In [1] c = me.EntityCollection(a=1, b=2)
In [2] c[<TAB>  # ipython will suggest 'a' and 'b' as completion options
```