### PR TITLE
shorten `Entity.__str__()`

### DIFF
--- a/src/mammos_entity/_entity.py
+++ b/src/mammos_entity/_entity.py
@@ -545,12 +545,9 @@ class Entity:
         return f"{self.__class__.__name__}({', '.join(args)})"
 
     def __str__(self) -> str:
-        new_line = "\n" if self.value.size > 4 else ""
-        repr_str = f"{self.ontology_label}(value={new_line}{self.value}"
-        if not self.unit.is_equivalent(u.dimensionless_unscaled):
-            repr_str += f",{new_line} unit={self.unit}"
+        repr_str = f"{self.ontology_label}({self.q!s}"
         if self.description:
-            repr_str += f",{new_line} description={self.description!r}"
+            repr_str += f", description={self.description!r}"
         return repr_str + ")"
 
     def _repr_html_(self) -> str:
@@ -676,23 +673,23 @@ def from_compatible(
         Users can pass the correct entity:
 
         >>> f(me.Entity("ThermodynamicTemperature"))
-        ThermodynamicTemperature(value=0.0, unit=K)
+        ThermodynamicTemperature(0.0 K)
 
         a compatible entity:
 
         >>> f(me.Entity("CurieTemperature"))
-        ThermodynamicTemperature(value=0.0, unit=K)
+        ThermodynamicTemperature(0.0 K)
 
         a quantity with compatible units:
 
         >>> import mammos_units as u
         >>> f(0 * u.K)
-        ThermodynamicTemperature(value=0.0, unit=K)
+        ThermodynamicTemperature(0.0 K)
 
         or a value:
 
         >>> f(0)
-        ThermodynamicTemperature(value=0.0, unit=deg_C)
+        ThermodynamicTemperature(0.0 deg_C)
 
         Incompatible entity or unit lead to errors:
 

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -179,6 +179,32 @@ def test_repr():
     assert eval(repr(e)) == e
 
 
+def test_str():
+    """Test readable string of an Entity.
+
+    Test 1: Test repr for Entity with scalar value
+    Test 2: Test repr for Entity with scalar value and description
+    Test 3: Test repr for Entity with 1D-vectorial value.
+    Test 4: Test repr for Entity with 2D-vectorial value.
+    Test 5: Test repr for unitless Entity.
+    """
+    e = me.Entity("CurieTemperature")
+    assert str(e) == "CurieTemperature(0.0 K)"
+
+    e = me.Entity("CurieTemperature", description="Estimated.")
+    assert str(e) == "CurieTemperature(0.0 K, description='Estimated.')"
+
+    e = me.Entity("ExternalMagneticField", value=[1, 2, 3])
+    assert str(e) == "ExternalMagneticField([1. 2. 3.] A / m)"
+
+    a = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+    e = me.Entity("ExternalMagneticField", value=a)
+    assert str(e) == f"ExternalMagneticField({e.q!s})"
+
+    e = me.Entity("DemagnetizingFactor")
+    assert str(e) == "DemagnetizingFactor(0.0)"
+
+
 def test_axis_labels():
     """Test different axis_label examples."""
     e_1 = me.Entity("ExternalMagneticField")


### PR DESCRIPTION
Closes #255 

- use the string representation of astropy quantities
- remove `value=` and `unit=`
- keep description with quotes (if nonempty)

Single numbers:
```python
>>> str(me.Entity("SpontaneousMagnetization", 800e3, "A/m", description="desc"))
"SpontaneousMagnetization(800000.0 A / m, description='desc')"
```

Arrays:
```python
>>> str(me.Entity("SpontaneousMagnetization",[800e3]*10, "A/m", description="desc"))
"SpontaneousMagnetization([800000. 800000. 800000. 800000. 800000. 800000. 800000. 800000. 800000.\n 800000.] A / m, description='desc')"
>>> print(str(me.Entity("SpontaneousMagnetization",[800e3]*10, "A/m", description="desc")))
SpontaneousMagnetization([800000. 800000. 800000. 800000. 800000. 800000. 800000. 800000. 800000.
 800000.] A / m, description='desc')
```

2D Arrays
```python
>>> print(str(me.Entity("SpontaneousMagnetization",np.array([[1, 2], [3, 4]]), "A/m", description="desc")))
SpontaneousMagnetization([[1. 2.]
 [3. 4.]] A / m, description='desc')
```