### PR TITLE
Force `description` to be a keyword argument in `Entity.__init__`

### DIFF
--- a/changes/257.changed.md
+++ b/changes/257.changed.md
@@ -1,0 +1,1 @@
+The `description` argument in the creation of an `Entity` must be a keyword argument when initializing an `Entity`.

--- a/examples/quickstart.ipynb
+++ b/examples/quickstart.ipynb
@@ -37,7 +37,7 @@
     "- the ontology label\n",
     "- the value(s)\n",
     "- the unit (optional but highly recommended; if not provided default units are taken from the ontology)\n",
-    "- a description (optional, empty string if not provided)"
+    "- a description (optional, must be a keyword argument, empty string if not provided)"
    ]
   },
   {
@@ -345,7 +345,7 @@
     }
    ],
    "source": [
-    "me.Entity(\"SpontaneousMagnetization\", 0.7, \"MA/m\", \"Measured with technique ABC\")"
+    "me.Entity(\"SpontaneousMagnetization\", 0.7, \"MA/m\", description=\"Measured with technique ABC\")"
    ]
   },
   {

--- a/src/mammos_entity/_entity.py
+++ b/src/mammos_entity/_entity.py
@@ -303,6 +303,7 @@ class Entity:
         ontology_label: str,
         value: mammos_entity.Entity | mammos_units.Quantity | numpy.typing.ArrayLike = 0,
         unit: str | None | mammos_units.UnitBase = None,
+        *,
         description: str = "",
     ):
         self.description = description


### PR DESCRIPTION
Closes #254 